### PR TITLE
gox OS options need to be space separated

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -30,5 +30,5 @@ deployment:
   commands:
    - go get github.com/mitchellh/gox
    - go get github.com/tcnksm/ghr
-   - gox -ldflags "-X main.Version=$BUILD_VERSION -X main.BuildDate=$BUILD_DATE" -output "dist/${CIRCLE_PROJECT_REPONAME}_{{.OS}}_{{.Arch}}" -os="linux,darwin"
+   - gox -ldflags "-X main.Version=$BUILD_VERSION -X main.BuildDate=$BUILD_DATE" -output "dist/${CIRCLE_PROJECT_REPONAME}_{{.OS}}_{{.Arch}}" -os="linux darwin"
    - ghr -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME --replace `git describe --tags` dist/


### PR DESCRIPTION
From `gox -h`

```
Platforms (OS/Arch):

  The operating systems and architectures to cross-compile for may be
  specified with the "-arch" and "-os" flags. These are space separated lists
  of valid GOOS/GOARCH values to build for, respectively. You may prefix an
  OS or Arch with "!" to negate and not build for that platform. If the list
  is made up of only negations, then the negations will come from the default
  list.
```