### PR TITLE
cleanup the http timeout using a context

### DIFF
--- a/check/check_http.go
+++ b/check/check_http.go
@@ -154,10 +154,8 @@ func (ch *HTTPCheck) Run() (*CheckResultSet, error) {
 		"id":   ch.Id,
 	}).Info("Running HTTP Check")
 
-	ctx, cancel := context.WithCancel(context.Background())
-	timer := time.AfterFunc(time.Duration(ch.Timeout)*time.Millisecond, func() {
-		cancel()
-	})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(ch.Timeout)*time.Millisecond)
+	defer cancel()
 
 	cr := NewCheckResult()
 	crs := NewCheckResultSet(ch, cr)
@@ -201,10 +199,6 @@ func (ch *HTTPCheck) Run() (*CheckResultSet, error) {
 		return crs, nil
 	}
 	endtime := utils.NowTimestampMillis()
-
-	if !timer.Stop() {
-		<-timer.C
-	}
 
 	cr.AddMetric(metric.NewMetric("code", "", metric.MetricNumber, resp.StatusCode, ""))
 	cr.AddMetric(metric.NewMetric("duration", "", metric.MetricNumber, endtime-starttime, "milliseconds"))

--- a/check/check_http.go
+++ b/check/check_http.go
@@ -202,7 +202,9 @@ func (ch *HTTPCheck) Run() (*CheckResultSet, error) {
 	}
 	endtime := utils.NowTimestampMillis()
 
-	timer.Stop()
+	if !timer.Stop() {
+		<-timer.C
+	}
 
 	cr.AddMetric(metric.NewMetric("code", "", metric.MetricNumber, resp.StatusCode, ""))
 	cr.AddMetric(metric.NewMetric("duration", "", metric.MetricNumber, endtime-starttime, "milliseconds"))


### PR DESCRIPTION
Saw this technique with golang 1.7. It uses a context to set a timeout on the entire http transaction. Simplifies the code, and is generally pretty cool.