### PR TITLE
Add sub-context to enable cancellation of checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,14 @@ go get github.com/golang/mock/mockgen
 With `$GOPATH/bin` in your `PATH`, run 
 
 ```
-mockgen -package=PKG -destination=PKG/obj_mock_test.go github.com/racker/rackspace-monitoring-poller/PKG Object
+mockgen -package={PKG} -destination={PKG}/{obj}_mock_test.go github.com/racker/rackspace-monitoring-poller/{PKG} {Object}
 ```
 
 where `PKG` is the sub-package that contains `Object` to mock. The file itself is named with `obj` as the snakecase
 normalization of `Object`.
+
+Don't forget to re-run `mockgen` when a mocked interface is altered since test-time compilation errors will result
+from incomplete interface implementations.
 
 Please note that due to https://github.com/golang/mock/issues/30 you may need to manually scrub the imports of 
 the generated file.

--- a/README.md
+++ b/README.md
@@ -65,3 +65,23 @@ With that running, open your browser to [http://localhost:6060/pkg/github.com/ra
 
 As you save file changes, just refresh the browser page to pick up the documentation changes.
 
+### Generating mocks
+
+[GoMock](https://github.com/golang/mock) is currently in use for unit testing where an interface needs to be mocked out to minimize scope of testing,
+system impact, etc. To generate a mock of an interface located in this repository first install mockgen
+
+```
+go get github.com/golang/mock/mockgen
+```
+
+With `$GOPATH/bin` in your `PATH`, run 
+
+```
+mockgen -package=PKG -destination=PKG/obj_mock_test.go github.com/racker/rackspace-monitoring-poller/PKG Object
+```
+
+where `PKG` is the sub-package that contains `Object` to mock. The file itself is named with `obj` as the snakecase
+normalization of `Object`.
+
+Please note that due to https://github.com/golang/mock/issues/30 you may need to manually scrub the imports of 
+the generated file.

--- a/check/check_http_test.go
+++ b/check/check_http_test.go
@@ -57,7 +57,7 @@ func TestHTTPSuccess(t *testing.T) {
 	  "target_resolver":"",
 	  "disabled":false
 	  }`, ts.URL)
-	check := check.NewCheck([]byte(checkData))
+	check := check.NewCheck([]byte(checkData), context.Background(), func() {})
 
 	// Run check
 	crs, err := check.Run()
@@ -99,7 +99,7 @@ func TestHTTPSuccessIncludeBodyAndHeaders(t *testing.T) {
 	  "target_resolver":"",
 	  "disabled":false
 	  }`, ts.URL)
-	check := check.NewCheck([]byte(checkData))
+	check := check.NewCheck([]byte(checkData), context.Background(), func() {})
 
 	// Run check
 	crs, err := check.Run()
@@ -151,7 +151,7 @@ func TestHTTPSuccessBodyMatch(t *testing.T) {
 	  "target_resolver":"",
 	  "disabled":false
 	  }`, ts.URL)
-	check := check.NewCheck([]byte(checkData))
+	check := check.NewCheck([]byte(checkData), context.Background(), func() {})
 
 	// Run check
 	crs, err := check.Run()
@@ -215,7 +215,7 @@ func TestHTTPClosed(t *testing.T) {
 	  "target_resolver":"",
 	  "disabled":false
 	  }`, ts.URL)
-	check := check.NewCheck([]byte(checkData))
+	check := check.NewCheck([]byte(checkData), context.Background(), func() {})
 
 	// Run check
 	crs, err := check.Run()
@@ -253,7 +253,7 @@ func TestHTTPTimeout(t *testing.T) {
 	  "target_resolver":"",
 	  "disabled":false
 	  }`, ts.URL)
-	check := check.NewCheck([]byte(checkData))
+	check := check.NewCheck([]byte(checkData), context.Background(), func() {})
 
 	// Run check
 	crs, err := check.Run()

--- a/check/check_ping_test.go
+++ b/check/check_ping_test.go
@@ -17,6 +17,7 @@
 package check_test
 
 import (
+	"context"
 	"fmt"
 	"github.com/golang/mock/gomock"
 	"github.com/racker/rackspace-monitoring-poller/check"
@@ -56,7 +57,7 @@ func TestPingCheck_ConfirmType(t *testing.T) {
 	const timeout = 15
 
 	checkData := fmt.Sprintf(checkDataTemplate, count, timeout)
-	c := check.NewCheck([]byte(checkData))
+	c := check.NewCheck([]byte(checkData), context.Background(), func() {})
 
 	assert.IsType(t, &check.PingCheck{}, c)
 }
@@ -79,7 +80,7 @@ func TestPingCheck_PingerConfigured(t *testing.T) {
 	mock.EXPECT().Statistics().Return(statistics)
 
 	checkData := fmt.Sprintf(checkDataTemplate, count, timeout)
-	c := check.NewCheck([]byte(checkData))
+	c := check.NewCheck([]byte(checkData), context.Background(), func() {})
 
 	// Run check since need to induce pinger usage
 	crs, err := c.Run()
@@ -111,7 +112,7 @@ func TestPingCheck_Success(t *testing.T) {
 	mock.EXPECT().Statistics().Return(statistics)
 
 	checkData := fmt.Sprintf(checkDataTemplate, count, timeout)
-	c := check.NewCheck([]byte(checkData))
+	c := check.NewCheck([]byte(checkData), context.Background(), func() {})
 
 	// Run check
 	crs, err := c.Run()
@@ -152,7 +153,7 @@ func TestPingCheck_Drops(t *testing.T) {
 	mock.EXPECT().Statistics().Return(statistics)
 
 	checkData := fmt.Sprintf(checkDataTemplate, count, timeout)
-	c := check.NewCheck([]byte(checkData))
+	c := check.NewCheck([]byte(checkData), context.Background(), func() {})
 
 	assert.IsType(t, &check.PingCheck{}, c)
 
@@ -194,7 +195,7 @@ func TestPingCheck_NoPermissionToPing(t *testing.T) {
 	mock.EXPECT().Statistics().Return(statistics)
 
 	checkData := fmt.Sprintf(checkDataTemplate, count, timeout)
-	c := check.NewCheck([]byte(checkData))
+	c := check.NewCheck([]byte(checkData), context.Background(), func() {})
 
 	assert.IsType(t, &check.PingCheck{}, c)
 

--- a/check/check_tcp_test.go
+++ b/check/check_tcp_test.go
@@ -134,7 +134,7 @@ func TestTCPRunSuccess(t *testing.T) {
 	  "target_resolver":"",
 	  "disabled":false
 	  }`, listenPort)
-	check := check.NewCheck([]byte(checkData))
+	check := check.NewCheck([]byte(checkData), context.Background(), func() {})
 
 	// Run check
 	crs, err := check.Run()
@@ -181,7 +181,7 @@ func TestTCPRunFailureClosedPort(t *testing.T) {
 	  "target_resolver":"",
 	  "disabled":false
 	  }`, listenPort)
-	check := check.NewCheck([]byte(checkData))
+	check := check.NewCheck([]byte(checkData), context.Background(), func() {})
 
 	// Run check
 	crs, err := check.Run()

--- a/check/unmarshal.go
+++ b/check/unmarshal.go
@@ -17,14 +17,18 @@
 package check
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 )
 
 // Given a received check request, this will unmarshal the request into one of the known polymorphic types.
 // This method needs to be updated to add to the known types.
-func NewCheck(rawParams json.RawMessage) Check {
-	checkBase := &CheckBase{}
+func NewCheck(rawParams json.RawMessage, checkCtx context.Context, cancel context.CancelFunc) Check {
+	checkBase := &CheckBase{
+		context: checkCtx,
+		cancel:  cancel,
+	}
 	err := json.Unmarshal(rawParams, &checkBase)
 	if err != nil {
 		log.Printf("Error unmarshalling checkbase")

--- a/poller/connection_stream.go
+++ b/poller/connection_stream.go
@@ -59,7 +59,7 @@ func NewConnectionStream(config *config.Config, rootCAs *x509.CertPool) *Connect
 	stream.stopCh = make(chan struct{}, 1)
 	for _, pz := range config.ZoneIds {
 		stream.scheduler[pz] = NewScheduler(pz, stream)
-		go stream.scheduler[pz].run()
+		go stream.scheduler[pz].runFrameConsumer()
 	}
 	return stream
 }


### PR DESCRIPTION
@goru97, @tpboudreau , @GeorgeJahad I was looking at the session go-loops and speculated this change might help for check commit/update logic. Feel free to chop it up or rip it out later if not applicable.