### PR TITLE
Fixing sporadic failures in TestTCPRunSuccess

### DIFF
--- a/check/check_tcp_test.go
+++ b/check/check_tcp_test.go
@@ -145,8 +145,8 @@ func TestTCPRunSuccess(t *testing.T) {
 	}
 
 	// Shutdown server
-	listener.Close()
 	server.Stop()
+	listener.Close()
 
 	// Validate Metrics
 	if crs.Status != "success" {

--- a/utils/test.go
+++ b/utils/test.go
@@ -251,7 +251,7 @@ func (s *BannerServer) Serve(listener net.Listener) {
 		}
 		log.WithField("err", err).Fatal("Unexpected error")
 	}
-	//log.Debug(conn.RemoteAddr(), "connected")
+	log.WithField("remoteAddr", conn.RemoteAddr()).Debug("accepted")
 	s.waitGroup.Add(1)
 	go s.serve(conn)
 }


### PR DESCRIPTION
A normal test run (with this change) looks like

```
/usr/local/go/bin/go test -v github.com/racker/rackspace-monitoring-poller/check -run ^TestTCPRunSuccess$

time="2017-02-13T14:22:05-06:00" level=info msg="New check chPzATCP" details="{\"port\":51818,\"ssl\":false}" disabled=false ipaddresses=map[default:127.0.0.1] period=30 target_alias=default target_hostname= target_resolver= timeout=15 type=remote.tcp

time="2017-02-13T14:22:05-06:00" level=info msg="Running TCP Check" address="127.0.0.1:51818" id=chPzATCP ssl=false type=remote.tcp

time="2017-02-13T14:22:05-06:00" level=info msg="disconnecting 127.0.0.1:51819"
ok       github.com/racker/rackspace-monitoring-poller/check     0.150s
```

however one of the sporadic failures was missing that "disconnecting" log:
https://travis-ci.org/racker/rackspace-monitoring-poller/builds/201249487#L383