### PR TITLE
add nil check for s.prepDetails.prepareToEndTimer

### DIFF
--- a/poller/session.go
+++ b/poller/session.go
@@ -300,7 +300,9 @@ func (s *EleSession) handlePollerPrepare(f *protocol.FrameMsg) {
 		s.respondFailureToPollerPrepare(s.prepDetails.srcPrepMsg, s.prepDetails.activePrep, protocol.PrepareResultStatusIgnored,
 			"Request supercedes a previous preparation")
 
-		s.prepDetails.prepareToEndTimer.Stop()
+		if s.prepDetails.prepareToEndTimer != nil {
+			s.prepDetails.prepareToEndTimer.Stop()
+		}
 
 		// fall through
 	}


### PR DESCRIPTION
Crash: 
```
goroutine 16 [running]:
panic(0x43e2520, 0xc4200100e0)
	/usr/local/go/src/runtime/panic.go:500 +0x1a1
time.(*Timer).Stop(0x0, 0xc42029a100)
	/usr/local/go/src/time/sleep.go:66 +0x26
github.com/racker/rackspace-monitoring-poller/poller.(*EleSession).handlePollerPrepare(0xc420248000, 0xc4202de000)
	/Users/dimi5963/projects/maas/go/src/github.com/racker/rackspace-monitoring-poller/poller/session.go:304 +0x342
github.com/racker/rackspace-monitoring-poller/poller.(*EleSession).handleFrame(0xc420248000, 0xc4202de000, 0x1, 0x1)
	/Users/dimi5963/projects/maas/go/src/github.com/racker/rackspace-monitoring-poller/poller/session.go:259 +0x38b
github.com/racker/rackspace-monitoring-poller/poller.(*EleSession).runFrameHandlingAndTimeout(0xc420248000)
	/Users/dimi5963/projects/maas/go/src/github.com/racker/rackspace-monitoring-poller/poller/session.go:229 +0x38f
created by github.com/racker/rackspace-monitoring-poller/poller.NewSession
	/Users/dimi5963/projects/maas/go/src/github.com/racker/rackspace-monitoring-poller/poller/session.go:115 +0x338
```