### PR TITLE
Initial integration of Prometheus

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -79,6 +79,12 @@ type Config struct {
 	// TimeoutPrepareEnd declares the max time to elapse between poller.prepare and poller.prepare.end, but
 	// is reset upon receipt of each poller.prepare.block.
 	TimeoutPrepareEnd time.Duration
+
+	// If configured, then metrics will be pushed to a Prometheus push gateway at the given URI.
+	// The URI may either have a scheme of "srv" or "tcp". A "srv" refers to a DNS SRV name and "tcp" conveys
+	// a host:port address, typically for local/onsite usage. The given service name will be qualified by the
+	// service "_prometheus" and proto "_tcp".
+	PrometheusUri string
 }
 
 type configEntry struct {
@@ -210,6 +216,10 @@ func (cfg *Config) DefineConfigEntries() []configEntry {
 			Name:     "monitoring_snet_region",
 			ValuePtr: &cfg.SnetRegion,
 			Allowed:  ValidSnetRegions,
+		},
+		{
+			Name:     "prometheus_uri",
+			ValuePtr: &cfg.PrometheusUri,
 		},
 	}
 }

--- a/contrib/local-endpoint.cfg
+++ b/contrib/local-endpoint.cfg
@@ -3,3 +3,4 @@ monitoring_id agentA
 monitoring_endpoints localhost:55000
 monitoring_private_zones pzA
 prometheus_uri tcp://localhost:9091
+#prometheus_uri srv://dfw1.stage.monitoring.api.rackspacecloud.com

--- a/contrib/local-endpoint.cfg
+++ b/contrib/local-endpoint.cfg
@@ -2,3 +2,4 @@ monitoring_token 000000000000000000000000000000000000000000000000000000000000000
 monitoring_id agentA
 monitoring_endpoints localhost:55000
 monitoring_private_zones pzA
+prometheus_uri tcp://localhost:9091

--- a/contrib/metrics/Dockerfile-prometheus
+++ b/contrib/metrics/Dockerfile-prometheus
@@ -1,0 +1,3 @@
+FROM prom/prometheus
+
+COPY prometheus.yml /etc/prometheus/

--- a/contrib/metrics/docker-compose.yml
+++ b/contrib/metrics/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '2'
+
+services:
+  pushgateway:
+    image: prom/pushgateway
+    ports:
+      - '9091:9091'
+    restart: always
+
+  prometheus:
+    build:
+      context: ./
+      dockerfile: Dockerfile-prometheus
+    ports:
+      - '9090:9090'
+    volumes:
+      - 'prometheus:/prometheus'
+
+volumes:
+  prometheus:

--- a/contrib/metrics/docker-compose.yml
+++ b/contrib/metrics/docker-compose.yml
@@ -15,6 +15,24 @@ services:
       - '9090:9090'
     volumes:
       - 'prometheus:/prometheus'
+    restart: always
+
+  cadvisor:
+    image: google/cadvisor:latest
+    ports:
+      - '9092:8080'
+    volumes:
+      - /var/run:/var/run:rw
+      - /:/rootfs:ro
+      - /sys:/sys:ro
+      - /var/lib/docker:/var/lib/docker:ro
+    restart: always
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - '3000:3000'
+    restart: always
 
 volumes:
   prometheus:

--- a/contrib/metrics/prometheus.yml
+++ b/contrib/metrics/prometheus.yml
@@ -12,5 +12,6 @@ scrape_configs:
       - targets: ['localhost:9090']
 
   - job_name: 'pushgateway'
+    honor_labels: true
     static_configs:
       - targets: ['pushgateway:9091']

--- a/contrib/metrics/prometheus.yml
+++ b/contrib/metrics/prometheus.yml
@@ -1,0 +1,16 @@
+global:
+  scrape_interval:     15s # By default, scrape targets every 15 seconds.
+
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: 'prometheus'
+
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 5s
+
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'pushgateway'
+    static_configs:
+      - targets: ['pushgateway:9091']

--- a/contrib/metrics/prometheus.yml
+++ b/contrib/metrics/prometheus.yml
@@ -9,9 +9,13 @@ scrape_configs:
     scrape_interval: 5s
 
     static_configs:
-      - targets: ['localhost:9090']
+      - targets: ['prometheus:9090']
 
   - job_name: 'pushgateway'
     honor_labels: true
     static_configs:
       - targets: ['pushgateway:9091']
+
+  - job_name: 'cadvisor'
+    static_configs:
+      - targets: ['cadvisor:8080']

--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,10 @@
-hash: a7d131ead8f805538f9744d651ea7839fbfdfceacb923a2c2e686ecf5ec19c84
-updated: 2017-03-16T11:25:32.285894-05:00
+hash: 55847d8b24308ffc396ed7976e9ac4e06d0ed27e5e958286a2d73a0825519f1d
+updated: 2017-03-31T09:35:31.032085502-05:00
 imports:
+- name: github.com/beorn7/perks
+  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+  subpackages:
+  - quantile
 - name: github.com/davecgh/go-spew
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
@@ -18,6 +22,10 @@ imports:
   subpackages:
   - gomock
   - mockgen
+- name: github.com/golang/protobuf
+  version: 2bba0603135d7d7f5cb73b2125beeda19c09f4ef
+  subpackages:
+  - proto
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jpillora/backoff
@@ -26,12 +34,35 @@ imports:
   version: acb9493f2794fd0f820de7a27a217dafbb1b65ea
 - name: github.com/mattn/go-isatty
   version: 57fdcb988a5c543893cc61bce354a6e24ab70022
+- name: github.com/matttproud/golang_protobuf_extensions
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+  subpackages:
+  - pbutil
 - name: github.com/mgutz/ansi
   version: 9520e82c474b0a04dd04f8a40959027271bab992
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
+- name: github.com/prometheus/client_golang
+  version: c5b7fccd204277076155f10851dad72b76a49317
+  subpackages:
+  - prometheus
+  - prometheus/push
+- name: github.com/prometheus/client_model
+  version: 6f3806018612930941127f2a7c6c453ba2c527d2
+  subpackages:
+  - go
+- name: github.com/prometheus/common
+  version: 49fee292b27bfff7f354ee0f64e1bc4850462edf
+  subpackages:
+  - expfmt
+  - internal/bitbucket.org/ww/goautoneg
+  - model
+- name: github.com/prometheus/procfs
+  version: a1dba9ce8baed984a2495b658c82687f8157b98f
+  subpackages:
+  - xfs
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/shirou/gopsutil

--- a/glide.yaml
+++ b/glide.yaml
@@ -26,3 +26,7 @@ import:
   version: ~0.3.2
 - package: github.com/mgutz/ansi
 - package: github.com/jpillora/backoff
+- package: github.com/prometheus/client_golang
+  version: ^0.8.0
+  subpackages:
+  - prometheus

--- a/poller/entry.go
+++ b/poller/entry.go
@@ -44,8 +44,10 @@ func Run(configFilePath string, insecure bool) {
 	log.WithField("guid", guid).Info("Assigned unique identifier")
 
 	rootCAs := config.LoadRootCAs(insecure, useStaging)
+
 	signalNotify := utils.HandleInterrupts()
 	ctx, cancel := context.WithCancel(context.Background())
+	StartMetricsPusher(ctx, cfg)
 	for {
 		stream := NewConnectionStream(ctx, cfg, rootCAs)
 		stream.Connect()

--- a/poller/metrics.go
+++ b/poller/metrics.go
@@ -32,6 +32,9 @@ const (
 	defaultPrometheusPushGatewayPort = "9091"
 	prometheusService                = "prometheus"
 	prometheusProto                  = "tcp"
+
+	metricLabelCheckType = "check_type"
+	metricLabelAddress   = "address"
 )
 
 var (

--- a/poller/metrics.go
+++ b/poller/metrics.go
@@ -1,0 +1,62 @@
+//
+// Copyright 2017 Rackspace
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package poller
+
+import (
+	"context"
+	log "github.com/Sirupsen/logrus"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/push"
+	"github.com/racker/rackspace-monitoring-poller/config"
+	"time"
+)
+
+const (
+	promPushGateway = "localhost:9091"
+)
+
+var (
+	metricsRegistry = prometheus.NewRegistry()
+)
+
+func StartMetricsPusher(ctx context.Context, cfg *config.Config) {
+	go runMetricsPusher(ctx, cfg)
+
+}
+
+func runMetricsPusher(ctx context.Context, cfg *config.Config) {
+	log.Debug("Metrics pusher waiting to start...")
+	defer log.Debug("Metric pusher exiting")
+
+	time.Sleep(10 * time.Second)
+
+	log.Debug("Metrics pusher started")
+	ticker := time.NewTicker(10 * time.Second)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-ticker.C:
+			pushMetrics(cfg)
+		}
+	}
+}
+
+func pushMetrics(cfg *config.Config) {
+	push.FromGatherer(cfg.Guid, nil, promPushGateway, metricsRegistry)
+}

--- a/poller/metrics.go
+++ b/poller/metrics.go
@@ -39,6 +39,9 @@ func StartMetricsPusher(ctx context.Context, cfg *config.Config) {
 }
 
 func runMetricsPusher(ctx context.Context, cfg *config.Config) {
+
+	metricsRegistry.MustRegister(prometheus.NewGoCollector())
+
 	log.Debug("Metrics pusher waiting to start...")
 	defer log.Debug("Metric pusher exiting")
 

--- a/poller/metrics.go
+++ b/poller/metrics.go
@@ -35,6 +35,7 @@ const (
 
 	metricLabelCheckType = "check_type"
 	metricLabelAddress   = "address"
+	metricLabelZone      = "zone"
 )
 
 var (
@@ -114,8 +115,8 @@ func runPrometheusMetricsPusher(ctx context.Context, cfg *config.Config) {
 	} else {
 		log.WithField("err", err).Debug("Failed to get our hostname")
 	}
-	if cfg.AgentName != "" {
-		groupings["agentName"] = cfg.AgentName
+	if cfg.AgentId != "" {
+		groupings["agentId"] = cfg.AgentId
 	}
 
 	log.Debug("Metrics pusher started")
@@ -132,7 +133,7 @@ func runPrometheusMetricsPusher(ctx context.Context, cfg *config.Config) {
 }
 
 func pushPrometheusMetrics(cfg *config.Config, promPushGateway string, groupings map[string]string) {
-	err := push.FromGatherer("poller", groupings, promPushGateway, metricsRegistry)
+	err := push.FromGatherer(cfg.AgentName, groupings, promPushGateway, metricsRegistry)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"err":     err,

--- a/poller/scheduler.go
+++ b/poller/scheduler.go
@@ -43,6 +43,7 @@ var (
 			Help:      "Conveys the number of checks currently scheduled per type",
 		},
 		[]string{
+			metricLabelZone,
 			metricLabelCheckType,
 		},
 	)
@@ -211,7 +212,7 @@ func (s *EleScheduler) reconcile(cp ChecksPrepared) {
 				log.WithField("checkId", ac.Id).Warn("Reconciling was told to start a check, but it already existed.")
 				existingCheck.Cancel()
 			} else {
-				gauge, err := metricsSchedulerScheduled.GetMetricWithLabelValues(ac.CheckType)
+				gauge, err := metricsSchedulerScheduled.GetMetricWithLabelValues(s.zoneID, ac.CheckType)
 				if err == nil {
 					gauge.Inc()
 				} else {
@@ -250,7 +251,7 @@ func (s *EleScheduler) reconcile(cp ChecksPrepared) {
 		checkToRemove := s.checks[checkIdToRemoveStr]
 		delete(s.checks, checkIdToRemoveStr)
 		checkToRemove.Cancel()
-		gauge, err := metricsSchedulerScheduled.GetMetricWithLabelValues(checkToRemove.GetCheckType())
+		gauge, err := metricsSchedulerScheduled.GetMetricWithLabelValues(s.zoneID, checkToRemove.GetCheckType())
 		if err == nil {
 			gauge.Dec()
 		} else {

--- a/poller/scheduler.go
+++ b/poller/scheduler.go
@@ -43,7 +43,7 @@ var (
 			Help:      "Conveys the number of checks currently scheduled per type",
 		},
 		[]string{
-			"check_type",
+			metricLabelCheckType,
 		},
 	)
 )

--- a/poller/scheduler.go
+++ b/poller/scheduler.go
@@ -25,12 +25,27 @@ import (
 	"fmt"
 	log "github.com/Sirupsen/logrus"
 	set "github.com/deckarep/golang-set"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/racker/rackspace-monitoring-poller/check"
 )
 
 const (
 	checkPreparationBufferSize = 10
 	checkLoggerDuration        = 5 * time.Minute
+)
+
+var (
+	metricsSchedulerScheduled = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "poller",
+			Subsystem: "scheduler",
+			Name:      "scheduled_checks",
+			Help:      "Conveys the number of checks currently scheduled per type",
+		},
+		[]string{
+			"check_type",
+		},
+	)
 )
 
 // EleScheduler implements Scheduler interface.
@@ -47,6 +62,10 @@ type EleScheduler struct {
 
 	scheduler CheckScheduler
 	executor  CheckExecutor
+}
+
+func init() {
+	metricsRegistry.MustRegister(metricsSchedulerScheduled)
 }
 
 // NewScheduler instantiates a new Scheduler with standard scheduling and executor behaviors.
@@ -191,6 +210,13 @@ func (s *EleScheduler) reconcile(cp ChecksPrepared) {
 			if exists {
 				log.WithField("checkId", ac.Id).Warn("Reconciling was told to start a check, but it already existed.")
 				existingCheck.Cancel()
+			} else {
+				gauge, err := metricsSchedulerScheduled.GetMetricWithLabelValues(ac.CheckType)
+				if err == nil {
+					gauge.Inc()
+				} else {
+					log.WithField("err", err).Warn("Failed to get gauge")
+				}
 			}
 			err := s.initiateCheck(*ac)
 			if err != nil {
@@ -224,6 +250,12 @@ func (s *EleScheduler) reconcile(cp ChecksPrepared) {
 		checkToRemove := s.checks[checkIdToRemoveStr]
 		delete(s.checks, checkIdToRemoveStr)
 		checkToRemove.Cancel()
+		gauge, err := metricsSchedulerScheduled.GetMetricWithLabelValues(checkToRemove.GetCheckType())
+		if err == nil {
+			gauge.Dec()
+		} else {
+			log.WithField("err", err).Warn("Failed to get gauge")
+		}
 	}
 
 	if log.GetLevel() >= log.DebugLevel {


### PR DESCRIPTION
## Description

This PR is an **evaluation** of integration with Prometheus statistics gathering backend. There are many frameworks available and various techniques to gathering metrics, such as push vs pull/scrape. The current code changes evaluate specifically a metric-push methodology due to private network constraints around poller deployments.

Statsd and Graphite are both important frameworks/backends to consider in amongst this approach. One reason for this particular WIP evaluation is that Prometheus already supports a [statsd exporter](https://github.com/prometheus/statsd_exporter) and a [graphite exporter](https://github.com/prometheus/graphite_exporter). Prometheus has its roots in golang and appears to be emerging as the defacto standard for Go based applications.

## Getting Prometheus up and running

```
cd contrib/metrics
docker-compose up -d
```

Open up the Prometheus frontend at http://localhost:9090/

TODO:

- [x] Ensure metrics pushing fails gracefully when push gateway is not present
- [x] Configure/lookup prometheus gateway endpoint
- [x] Test service name lookup of Prometheus push gateway