### PR TITLE
Balance the connection's "Connected" log with "Disconnected"

### DIFF
--- a/poller/connection.go
+++ b/poller/connection.go
@@ -140,6 +140,10 @@ func (conn *EleConnection) Connect(ctx context.Context, config *config.Config, t
 // Close closes the session
 func (conn *EleConnection) Close() {
 	if conn.conn != nil {
+		log.WithFields(log.Fields{
+			"prefix":         conn.GetLogPrefix(),
+			"remote_address": conn.address,
+		}).Info("Disconnected")
 		conn.conn.Close()
 		conn.conn = nil
 	}


### PR DESCRIPTION
With this change the logs will contain pairings such as

```
time="Fri, 31 Mar 2017 12:08:43 CDT" level=info msg="Connecting to agent/poller endpoint" timeout=10s 
time="Fri, 31 Mar 2017 12:08:44 CDT" level=info msg=Connected remote_address=50.57.194.13:443 
time="Fri, 31 Mar 2017 12:08:44 CDT" level=debug msg="frame handling starting" 
time="Fri, 31 Mar 2017 12:08:44 CDT" level=debug msg="send starting" 
time="Fri, 31 Mar 2017 12:08:44 CDT" level=debug msg="read starting" 
time="Fri, 31 Mar 2017 12:08:44 CDT" level=debug msg="socket send" data="{\"v\":\"1\",\"id\":1,\"target\":\"endpoint\",\"source\":\"cfb694c3-2466-4c42-9901-e23bfb8788d5\",\"method\":\"handshake.hello\",\"params\":{\"token\":\"fd0626aa72e7cd27cbd5f68e9668782f83b91983f1ca1643d5627f13de7fdd74.777788\",\"agent_id\":\"-poller-\",\"agent_name\":\"remote_poller\",\"process_version\":\"dev\",\"bundle_version\":\"dev\",\"zone_ids\":[\"pzhXCBceYL\"],\"features\":[{\"name\":\"poller\",\"disabled\":false}]}}" 
...snip...
time="Fri, 31 Mar 2017 12:08:54 CDT" level=warning msg="Closing connection due to expired auth" 
time="Fri, 31 Mar 2017 12:08:54 CDT" level=info msg=Disconnected remote_address="agent-endpoint-ord.staging.monitoring.api.rackspacecloud.com:443" 
time="Fri, 31 Mar 2017 12:08:54 CDT" level=debug msg="Connection sleeping" address="agent-endpoint-ord.staging.monitoring.api.rackspacecloud.com:443" timeout=25s 
...snip...
time="Fri, 31 Mar 2017 12:09:19 CDT" level=debug msg=Reconnecting address="agent-endpoint-ord.staging.monitoring.api.rackspacecloud.com:443" 
time="Fri, 31 Mar 2017 12:09:19 CDT" level=info msg="Connecting to agent/poller endpoint" timeout=10s 
time="Fri, 31 Mar 2017 12:09:19 CDT" level=info msg=Connected remote_address=50.57.194.13:443 
```