### PR TITLE
remove accept-encoding header

### DIFF
--- a/check/check_http.go
+++ b/check/check_http.go
@@ -159,7 +159,6 @@ func (ch *HTTPCheck) Run() (*ResultSet, error) {
 	req = req.WithContext(httptrace.WithClientTrace(ctx, trace))
 
 	// Add Headers
-	req.Header.Add("Accept-Encoding", "gzip,deflate")
 	req.Header.Add("User-Agent", UserAgent)
 	req.Host = host
 	for key, value := range ch.Details.Headers {


### PR DESCRIPTION
# Why

The golang http client will, by default, decode compressed responses.