### PR TITLE
fixes the truncated value

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -356,7 +356,7 @@ func (ch *Base) AddTLSMetrics(cr *Result, state tls.ConnectionState) *TLSMetrics
 }
 
 func (ch *Base) readLimit(conn io.Reader, limit int64) ([]byte, error) {
-	body, err := ioutil.ReadAll(io.LimitReader(conn, limit))
+	body, err := ioutil.ReadAll(io.LimitReader(conn, limit+1))
 	if err != nil && err != io.EOF {
 		return nil, err
 	}

--- a/check/check_http.go
+++ b/check/check_http.go
@@ -213,13 +213,17 @@ func (ch *HTTPCheck) Run() (*ResultSet, error) {
 		}
 	}
 
-	truncated := resp.ContentLength - int64(len(body))
+	truncated := int64(0)
+	if int64(len(body)) > MaxHTTPResponseBodyLength {
+		truncated = int64(1)
+	}
+
 	codeStr := strconv.Itoa(resp.StatusCode)
 
 	cr.AddMetric(metric.NewMetric("code", "", metric.MetricString, codeStr, ""))
 	cr.AddMetric(metric.NewMetric("duration", "", metric.MetricNumber, endtime-starttime, "milliseconds"))
 	cr.AddMetric(metric.NewMetric("bytes", "", metric.MetricNumber, len(body), "bytes"))
-	cr.AddMetric(metric.NewMetric("truncated", "", metric.MetricNumber, truncated, "bytes"))
+	cr.AddMetric(metric.NewMetric("truncated", "", metric.MetricNumber, truncated, "bool"))
 
 	if ch.Details.IncludeBody {
 		cr.AddMetric(metric.NewMetric("body", "", metric.MetricString, string(body), ""))


### PR DESCRIPTION
* should be represented as a zero or one (it gets converted later to a
  true/false)
* Change the LimitReader to read limit+1 to allow for detection of the
  truncation