### PR TITLE
Add dev-time option to use a non-TLS connection to agent endpoint

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -338,3 +338,7 @@ func (cfg *Config) ComputeWriteDeadline(offset time.Duration) time.Time {
 func IsUsingStaging() bool {
 	return os.Getenv(EnvStaging) == EnabledEnvOpt
 }
+
+func IsUsingCleartext() bool {
+	return os.Getenv(EnvCleartext) == EnabledEnvOpt
+}

--- a/config/constants.go
+++ b/config/constants.go
@@ -59,5 +59,6 @@ const (
 
 	EnvStaging    = "STAGING"
 	EnvDevCA      = "DEV_CA"
+	EnvCleartext  = "CLEARTEXT"
 	EnabledEnvOpt = "1"
 )

--- a/poller/connection_stream.go
+++ b/poller/connection_stream.go
@@ -46,10 +46,6 @@ const (
 	EventTypeDroppedMetric = "dropped"
 	// EventTypeAllConnectionsLost indicates that all endpoint connections were lost
 	EventTypeAllConnectionsLost = "allConnectionsLost"
-	// EventTypeConnected indicates that TCP connection has been established
-	EventTypeConnected = "connected"
-	// EventTypeDisconnected indicates that TCP connection has been lost
-	EventTypeDisconnected = "disconnected"
 )
 
 // EleConnectionStream implements ConnectionStream
@@ -333,7 +329,6 @@ reconnect:
 		if err != nil {
 			goto conn_error
 		}
-		cs.EmitEvent(utils.NewEvent(EventTypeConnected, conn))
 
 		// Successful connection. reset backoff
 		b.Reset()
@@ -371,7 +366,6 @@ reconnect:
 			"address": addr,
 		}).Errorf("Error: %v", err)
 	new_connection:
-		cs.EmitEvent(utils.NewEvent(EventTypeDisconnected, nil))
 		sleepDuration := b.Duration()
 		log.WithFields(log.Fields{
 			"prefix":  cs.GetLogPrefix(),

--- a/poller/connection_stream_test.go
+++ b/poller/connection_stream_test.go
@@ -147,7 +147,7 @@ func TestEleConnectionStream_Connect_ClearText(t *testing.T) {
 	cs.RegisterEventConsumer(consumer)
 
 	cs.Connect()
-	consumer.waitFor(t, 10*time.Millisecond, poller.EventTypeConnected, gomock.Eq(conn))
+	consumer.waitFor(t, 10*time.Millisecond, poller.EventTypeRegister, gomock.Eq(conn))
 	cancel()
 }
 

--- a/poller/connection_stream_test.go
+++ b/poller/connection_stream_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"time"
+	"os"
 )
 
 func TestConnectionStream_Connect(t *testing.T) {
@@ -70,7 +71,7 @@ func TestConnectionStream_Connect(t *testing.T) {
 			done := make(chan struct{}, 1)
 
 			conn := NewMockConnection(ctrl)
-			conn.EXPECT().Connect(gomock.Any(), gomock.Any(), gomock.Any())
+			conn.EXPECT().Connect(gomock.Any(), gomock.Any(), gomock.Not(nil))
 			conn.EXPECT().Done().AnyTimes().Return(done)
 			conn.EXPECT().GetLogPrefix().AnyTimes().Return("1234")
 			conn.EXPECT().Close().AnyTimes().Do(func() {
@@ -107,6 +108,47 @@ func TestConnectionStream_Connect(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEleConnectionStream_Connect_ClearText(t *testing.T) {
+	os.Setenv(config.EnvCleartext, config.EnabledEnvOpt)
+	defer os.Unsetenv(config.EnvCleartext)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	conn := NewMockConnection(ctrl)
+	// NOTE: expecting the nil tlsConfig is the primary expectation of this case
+	conn.EXPECT().Connect(gomock.Any(), gomock.Any(), gomock.Nil())
+	conn.EXPECT().GetLogPrefix().AnyTimes().Return("1234")
+
+	preAuthedChannel := make(chan struct{}, 1)
+	close(preAuthedChannel)
+	conn.EXPECT().Authenticated().AnyTimes().Return(preAuthedChannel)
+
+	done := make(chan struct{}, 1)
+	conn.EXPECT().Done().AnyTimes().Return(done)
+	conn.EXPECT().Close().AnyTimes().Do(func() {
+		t.Log("Mock conn is closing")
+		close(done)
+	})
+
+	connFactory := func(address string, guid string, stream poller.ChecksReconciler) poller.Connection {
+		return conn
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cs := poller.NewCustomConnectionStream(ctx, &config.Config{
+		UseSrv:    false,
+		Addresses: []string{"localhost"},
+	}, nil, connFactory)
+
+	consumer := newPhasingEventConsumer()
+	cs.RegisterEventConsumer(consumer)
+
+	cs.Connect()
+	consumer.waitFor(t, 10*time.Millisecond, poller.EventTypeConnected, gomock.Eq(conn))
+	cancel()
 }
 
 func TestConnectionsByHost_ChooseBest(t *testing.T) {
@@ -463,8 +505,8 @@ func (f *mockConnFactory) add(conn *MockConnection) *MockConnection {
 	auth := make(chan struct{}, 1)
 	conn.EXPECT().Connect(gomock.Any(), gomock.Any(), gomock.Any()).
 		Do(func(ctx context.Context, config *config.Config, tlsConfig *tls.Config) {
-			f.connected <- struct{}{}
-		})
+		f.connected <- struct{}{}
+	})
 	conn.EXPECT().Authenticated().AnyTimes().Return(auth)
 	conn.EXPECT().SetAuthenticated().Do(func() {
 		close(auth)

--- a/poller/entry.go
+++ b/poller/entry.go
@@ -24,6 +24,7 @@ import (
 	"github.com/satori/go.uuid"
 	"os"
 	"time"
+	"crypto/x509"
 )
 
 func generatePollerGuid() string {
@@ -49,7 +50,10 @@ func Run(configFilePath string, insecure bool) {
 
 	log.WithField("guid", guid).Info("Assigned unique identifier")
 
-	rootCAs := config.LoadRootCAs(insecure, useStaging)
+	var rootCAs *x509.CertPool
+	if !config.IsUsingCleartext() {
+		rootCAs = config.LoadRootCAs(insecure, useStaging)
+	}
 
 	signalNotify := utils.HandleInterrupts()
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
This change allows for the `ele-server-agent-endpoint` to be run locally in an IDE, such as IntelliJ, and connect to it with a locally running poller. In that scenario the poller is connecting directly to the NodeJS process in which case no TLS termination is involved.

The poller config ends up looking like:

```
monitoring_token *****.*****
monitoring_endpoints localhost:50040
monitoring_private_zones pz...
```