### PR TITLE
Add configurable option to distribute metrics to a statsd receiver

### DIFF
--- a/check/check_http.go
+++ b/check/check_http.go
@@ -30,7 +30,7 @@ import (
 	"strconv"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	protocol "github.com/racker/rackspace-monitoring-poller/protocol/check"
 	"github.com/racker/rackspace-monitoring-poller/protocol/metric"
 	"github.com/racker/rackspace-monitoring-poller/utils"

--- a/check/check_ping.go
+++ b/check/check_ping.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	protocol "github.com/racker/rackspace-monitoring-poller/protocol/check"
 	"github.com/racker/rackspace-monitoring-poller/protocol/metric"
 	"github.com/racker/rackspace-monitoring-poller/utils"

--- a/check/check_plugin.go
+++ b/check/check_plugin.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/racker/rackspace-monitoring-poller/protocol/metric"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	protocol "github.com/racker/rackspace-monitoring-poller/protocol/check"
 )
 

--- a/check/check_tcp.go
+++ b/check/check_tcp.go
@@ -27,7 +27,7 @@ import (
 	"strconv"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	protocheck "github.com/racker/rackspace-monitoring-poller/protocol/check"
 	"github.com/racker/rackspace-monitoring-poller/protocol/metric"
 	"github.com/racker/rackspace-monitoring-poller/utils"

--- a/check/check_tcp_test.go
+++ b/check/check_tcp_test.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"testing"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/racker/rackspace-monitoring-poller/check"
 	"github.com/racker/rackspace-monitoring-poller/utils"
 	"github.com/stretchr/testify/require"

--- a/check/pinger.go
+++ b/check/pinger.go
@@ -22,7 +22,7 @@ import (
 
 	"bytes"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/pkg/errors"
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/ipv4"

--- a/commands/ping.go
+++ b/commands/ping.go
@@ -2,7 +2,7 @@ package commands
 
 import (
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/racker/rackspace-monitoring-poller/check"
 	protocheck "github.com/racker/rackspace-monitoring-poller/protocol/check"
 	"github.com/spf13/cobra"

--- a/config/certs.go
+++ b/config/certs.go
@@ -18,8 +18,8 @@ package config
 
 import (
 	"crypto/x509"
-	"github.com/Sirupsen/logrus"
-	log "github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"io/ioutil"
 	"os"
 )

--- a/config/config.go
+++ b/config/config.go
@@ -29,7 +29,7 @@ import (
 
 	"bytes"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"text/template"
 )
 
@@ -43,7 +43,7 @@ const (
 	DefaultTimeoutRead            = 10 * time.Second
 	DefaultTimeoutWrite           = 10 * time.Second
 	DefaultTimeoutPrepareEnd      = 60 * time.Second
-	DefaultTimeoutAuth            = 10 * time.Second
+	DefaultTimeoutAuth            = 30 * time.Second
 	DefaultAgentId                = "-poller-"
 	DefaultReconnectMinBackoff    = 25 * time.Second
 	DefaultReconnectMaxBackoff    = 180 * time.Second
@@ -95,6 +95,10 @@ type Config struct {
 	// a host:port address, typically for local/onsite usage. The given service name will be qualified by the
 	// service "_prometheus" and proto "_tcp".
 	PrometheusUri string
+
+	// If configured, all check's metrics will be distributed to the configured statsd endpoint.
+	// The address is formatted as host:port.
+	StatsdEndpoint string
 }
 
 type configEntry struct {
@@ -236,6 +240,10 @@ func (cfg *Config) DefineConfigEntries() []configEntry {
 		{
 			Name:     "prometheus_uri",
 			ValuePtr: &cfg.PrometheusUri,
+		},
+		{
+			Name:     "statsd_endpoint",
+			ValuePtr: &cfg.StatsdEndpoint,
 		},
 	}
 }

--- a/config/endpoint_config.go
+++ b/config/endpoint_config.go
@@ -22,7 +22,7 @@ import (
 
 	"os"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type EndpointConfig struct {

--- a/contrib/vms/.gitignore
+++ b/contrib/vms/.gitignore
@@ -1,0 +1,2 @@
+/.vagrant
+/*.log

--- a/endpoint/agent.go
+++ b/endpoint/agent.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	set "github.com/deckarep/golang-set"
 	"github.com/fsnotify/fsnotify"
 	"github.com/racker/rackspace-monitoring-poller/check"

--- a/endpoint/agent_tracker.go
+++ b/endpoint/agent_tracker.go
@@ -17,7 +17,7 @@
 package endpoint
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/racker/rackspace-monitoring-poller/protocol"
 
 	"context"

--- a/endpoint/basic_server.go
+++ b/endpoint/basic_server.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/racker/rackspace-monitoring-poller/config"
 	"github.com/racker/rackspace-monitoring-poller/protocol"
 	"github.com/racker/rackspace-monitoring-poller/utils"

--- a/endpoint/metrics_router.go
+++ b/endpoint/metrics_router.go
@@ -18,7 +18,7 @@ package endpoint
 
 import (
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/racker/rackspace-monitoring-poller/config"
 )
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,14 @@
-hash: c85a88923357d85c7fc98370d3700d0a4d6d6e0826d849ebe4f471d361c69cb4
-updated: 2017-04-20T08:35:08.620676482-05:00
+hash: 40feb3ec39841b0cb6b38889f3e96b5f0e8b4ead44778e31371f33481215b096
+updated: 2017-10-10T13:25:25.049139962-05:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
   subpackages:
   - quantile
+- name: github.com/DataDog/datadog-go
+  version: 0ddda6bee21174ef6c4873647cb0d6ec9cba996f
+  subpackages:
+  - statsd
 - name: github.com/davecgh/go-spew
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
@@ -14,26 +18,26 @@ imports:
 - name: github.com/fsnotify/fsnotify
   version: 629574ca2a5df945712d3079857300b5e4da0236
 - name: github.com/go-ole/go-ole
-  version: de8695c8edbf8236f30d6e1376e20b198a028d42
+  version: 2ca6d5950a178eae0d0b51e0993facc42f3cefe2
   subpackages:
   - oleutil
 - name: github.com/golang/mock
-  version: bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
+  version: 6e20fef50e74e443696bc32b693cf286b612d45b
   subpackages:
   - gomock
   - mockgen
 - name: github.com/golang/protobuf
-  version: 2bba0603135d7d7f5cb73b2125beeda19c09f4ef
+  version: 130e6b02ab059e7b717a096f397c5b60111cae74
   subpackages:
   - proto
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jpillora/backoff
-  version: 06c7a16c845dc8e0bf575fafeeca0f5462f5eb4d
+  version: 8eab2debe79d12b7bd3d10653910df25fa9552ba
 - name: github.com/mattn/go-colorable
-  version: acb9493f2794fd0f820de7a27a217dafbb1b65ea
+  version: ad5389df28cdac544c99bd7b9161a0b5b6ca9d1b
 - name: github.com/mattn/go-isatty
-  version: 57fdcb988a5c543893cc61bce354a6e24ab70022
+  version: a5cdd64afdee435007ee3e9f6ed4684af949d568
 - name: github.com/matttproud/golang_protobuf_extensions
   version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
@@ -56,19 +60,19 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 9e0844febd9e2856f839c9cb974fbd676d1755a8
+  version: 1bab55dd05dbff384524a6a1c99006d9eb5f139b
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: 1e2146578273cef808354faa16a1922e0b5d6b2f
+  version: e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2
   subpackages:
   - xfs
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/shirou/gopsutil
-  version: e49a95f3d5f824c3f9875ca49e54e4fef17f82cf
+  version: 6e221c482653ef05c9f6a7bf71ddceea0e40bac5
   subpackages:
   - cpu
   - disk
@@ -79,32 +83,37 @@ imports:
   - process
 - name: github.com/shirou/w32
   version: bb4de0191aa41b5507caa14b0650cdbddcd9280b
-- name: github.com/Sirupsen/logrus
+- name: github.com/sirupsen/logrus
   version: 0208149b40d863d2c1a2f8fe5753096a9cf2cc8b
 - name: github.com/spf13/cobra
-  version: fcd0c5a1df88f5d6784cb4feead962c3f3d0b66c
+  version: 4d6af280c76ff7d266434f2dba207c4b75dfc076
 - name: github.com/spf13/pflag
-  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
+  version: a9789e855c7696159b7db0db7f440b449edf2b31
 - name: github.com/StackExchange/wmi
-  version: 9f32b5905fd6ce7384093f9d048437e79f7b4d85
+  version: ea383cf3ba6ec950874b8486cd72356d007c768f
 - name: github.com/stretchr/testify
   version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
   - require
 - name: github.com/x-cray/logrus-prefixed-formatter
-  version: 54b7cd10b359d569484cc6b6ffd21d4649dcd148
+  version: bb2702d423886830dee131692131d35648c382e2
+- name: golang.org/x/crypto
+  version: 9419663f5a44be8b34ca85f08abc5fe1be11f8a3
+  subpackages:
+  - ssh/terminal
 - name: golang.org/x/net
-  version: 906cda9512f77671ab44f8c8563b13a8e707b230
+  version: a04bdaca5b32abe1c069418fb7088ae607de5bd0
   subpackages:
   - bpf
   - icmp
   - internal/iana
-  - internal/netreflect
+  - internal/socket
   - ipv4
   - ipv6
 - name: golang.org/x/sys
-  version: 76cc09b634294339fa19ec41b5f2a0b3932cea8b
+  version: ebfc5b4631820b793c9010c87fd8fef0f39eb082
   subpackages:
   - unix
+  - windows
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,6 @@
 package: github.com/racker/rackspace-monitoring-poller
 import:
-- package: github.com/Sirupsen/logrus
+- package: github.com/sirupsen/logrus
   version: v0.11.4
 - package: github.com/shirou/gopsutil
   version: ~v2.17.02
@@ -31,3 +31,7 @@ import:
   version: ^0.8.0
 - package: github.com/x-cray/logrus-prefixed-formatter
   version: ^0.4.0
+- package: github.com/DataDog/datadog-go
+  version: ^1.1.0
+  subpackages:
+  - statsd

--- a/hostinfo/hostinfo_cpu.go
+++ b/hostinfo/hostinfo_cpu.go
@@ -18,7 +18,7 @@ package hostinfo
 
 import (
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/racker/rackspace-monitoring-poller/protocol/hostinfo"
 	"github.com/racker/rackspace-monitoring-poller/utils"
 	"github.com/shirou/gopsutil/cpu"

--- a/hostinfo/hostinfo_filesystem.go
+++ b/hostinfo/hostinfo_filesystem.go
@@ -17,7 +17,7 @@
 package hostinfo
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/racker/rackspace-monitoring-poller/protocol/hostinfo"
 	"github.com/racker/rackspace-monitoring-poller/utils"
 	"github.com/shirou/gopsutil/disk"

--- a/hostinfo/hostinfo_memory.go
+++ b/hostinfo/hostinfo_memory.go
@@ -17,7 +17,7 @@
 package hostinfo
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/racker/rackspace-monitoring-poller/protocol/hostinfo"
 	"github.com/racker/rackspace-monitoring-poller/utils"
 	"github.com/shirou/gopsutil/mem"

--- a/hostinfo/hostinfo_processes.go
+++ b/hostinfo/hostinfo_processes.go
@@ -17,7 +17,7 @@
 package hostinfo
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/racker/rackspace-monitoring-poller/protocol/hostinfo"
 	"github.com/racker/rackspace-monitoring-poller/utils"
 	"github.com/shirou/gopsutil/process"

--- a/hostinfo/hostinfo_system.go
+++ b/hostinfo/hostinfo_system.go
@@ -17,7 +17,7 @@
 package hostinfo
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/racker/rackspace-monitoring-poller/protocol/hostinfo"
 	"github.com/shirou/gopsutil/host"
 	"runtime"

--- a/poller.go
+++ b/poller.go
@@ -29,7 +29,7 @@ import (
 	"syscall"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	prefixed "github.com/x-cray/logrus-prefixed-formatter"
 
 	"github.com/racker/rackspace-monitoring-poller/commands"

--- a/poller/checks_preparation.go
+++ b/poller/checks_preparation.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"fmt"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/racker/rackspace-monitoring-poller/protocol"
 	"github.com/racker/rackspace-monitoring-poller/protocol/check"

--- a/poller/connection.go
+++ b/poller/connection.go
@@ -23,7 +23,7 @@ import (
 	"net"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/racker/rackspace-monitoring-poller/config"
 )

--- a/poller/connection_stream_test.go
+++ b/poller/connection_stream_test.go
@@ -3,20 +3,19 @@ package poller_test
 import (
 	"testing"
 
-	"container/list"
 	"context"
-	"crypto/tls"
-	"fmt"
 	"github.com/golang/mock/gomock"
 	"github.com/racker/rackspace-monitoring-poller/check"
 	"github.com/racker/rackspace-monitoring-poller/config"
 	"github.com/racker/rackspace-monitoring-poller/poller"
-	"github.com/racker/rackspace-monitoring-poller/protocol"
-	"github.com/racker/rackspace-monitoring-poller/utils"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"time"
 	"os"
+	"net"
+	"github.com/stretchr/testify/require"
+	"strconv"
+	"github.com/racker/rackspace-monitoring-poller/protocol/metric"
+	"strings"
 )
 
 func TestConnectionStream_Connect(t *testing.T) {
@@ -484,126 +483,67 @@ func TestEleConnectionStream_SendMetrics_NoConnections(t *testing.T) {
 	consumer.waitFor(t, 5*time.Millisecond, poller.EventTypeDroppedMetric, gomock.Eq(crs))
 }
 
-type mockConnFactory struct {
-	conns     *list.List
-	connected chan struct{}
-	frames    chan protocol.Frame
-	guids     []string
-}
+func TestEleConnectionStream_UseStatsdDistributor(t *testing.T) {
+	factory := newMockConnFactory()
 
-func newMockConnFactory() *mockConnFactory {
-	return &mockConnFactory{
-		conns:     list.New(),
-		connected: make(chan struct{}, 10),
-		frames:    make(chan protocol.Frame, 10),
-		guids:     make([]string, 0),
-	}
-}
+	udpConn, err := net.ListenUDP("udp4", nil)
+	require.NoError(t, err)
+	defer udpConn.Close()
 
-func (f *mockConnFactory) add(conn *MockConnection) *MockConnection {
-	f.conns.PushBack(conn)
-	auth := make(chan struct{}, 1)
-	conn.EXPECT().Connect(gomock.Any(), gomock.Any(), gomock.Any()).
-		Do(func(ctx context.Context, config *config.Config, tlsConfig *tls.Config) {
-		f.connected <- struct{}{}
-	})
-	conn.EXPECT().Authenticated().AnyTimes().Return(auth)
-	conn.EXPECT().SetAuthenticated().Do(func() {
-		close(auth)
-	})
-	return conn
-}
-
-func (f *mockConnFactory) interceptSend(frame protocol.Frame) {
-	f.frames <- frame
-}
-
-func (f *mockConnFactory) waitForFrame(t *testing.T, timeout time.Duration) protocol.Frame {
-	select {
-	case <-time.After(timeout):
-		assert.Fail(t, "Did not see frame")
-		return nil
-	case f := <-f.frames:
-		return f
-	}
-}
-
-func (f *mockConnFactory) produce(address string, guid string, checksReconciler poller.ChecksReconciler) poller.Connection {
-	if f.conns.Len() > 0 {
-		connection := f.conns.Remove(f.conns.Front()).(poller.Connection)
-		f.guids = append(f.guids, guid)
-		return connection
-	} else {
-		return nil
-	}
-}
-
-func (f *mockConnFactory) waitForConnections(t *testing.T, expect int, timeout time.Duration) {
-	var seen int
-
-	limiter := time.After(timeout)
-
-	for {
-		select {
-		case <-limiter:
-			require.Fail(t, "Did not see enough connections")
-			return
-
-		case <-f.connected:
-			seen++
-			if seen >= expect {
+	pktChan := make(chan []byte, 100)
+	done := make(chan struct{}, 1)
+	defer close(done)
+	go func() {
+		for {
+			select {
+			case <-done:
 				return
+
+			default:
+				buf := make([]byte, 500)
+				_, _, err := udpConn.ReadFrom(buf)
+				if err != nil {
+					t.Fatal(err)
+					return
+				}
+				pktChan <- buf
 			}
 		}
+	}()
+
+	cfg := factory.renderConfig(1)
+	cfg.Token = "***.123456"
+	addr := udpConn.LocalAddr()
+	ourUdpAddr := addr.(*net.UDPAddr)
+	cfg.StatsdEndpoint = net.JoinHostPort("127.0.0.1", strconv.FormatInt(int64(ourUdpAddr.Port), 10))
+
+	consumer := newPhasingEventConsumer()
+
+	ctx, _ := context.WithCancel(context.Background())
+
+	cs := poller.NewCustomConnectionStream(ctx, cfg, nil, factory.produce)
+	cs.RegisterEventConsumer(consumer)
+	cs.Connect()
+
+	crs := check.ResultSet{
+		Check: &check.PingCheck{},
 	}
-}
+	crs.Check.SetCheckType("remote.ping")
+	crs.Check.SetID("chTEST")
 
-func (f *mockConnFactory) renderConfig(addresses int) *config.Config {
-	cfg := &config.Config{
-		UseSrv:    false,
-		Addresses: make([]string, addresses),
+	metrics := make(map[string]*metric.Metric)
+	metrics["average"] = metric.NewMetric("average", "", metric.MetricFloat, 4.5, "")
+	crs.Metrics = []*check.Result{
+		{Metrics: metrics},
 	}
 
-	for i := 0; i < addresses; i++ {
-		cfg.Addresses[i] = fmt.Sprintf("c%d", i+1)
-	}
+	cs.SendMetrics(&crs)
 
-	return cfg
-}
-
-type phasingEventConsumer struct {
-	events chan utils.Event
-}
-
-func newPhasingEventConsumer() *phasingEventConsumer {
-	return &phasingEventConsumer{
-		events: make(chan utils.Event, 10),
-	}
-}
-
-func (c *phasingEventConsumer) HandleEvent(evt utils.Event) error {
-	c.events <- evt
-	return nil
-}
-
-func (c *phasingEventConsumer) waitFor(t *testing.T, timeout time.Duration, eventType string, targetMatcher gomock.Matcher) {
 	select {
-	case evt := <-c.events:
-		assert.Equal(t, eventType, evt.Type(), "Wrong event type")
-		if !targetMatcher.Matches(evt.Target()) {
-			assert.Fail(t, targetMatcher.String())
-		}
-	case <-time.After(timeout):
+	case <-time.After(1 * time.Second):
 		t.Fail()
-		//assert.Fail(t, "Did not observe an event")
-	}
-}
 
-func (c *phasingEventConsumer) assertNoEvent(t *testing.T, timeout time.Duration) {
-	select {
-	case evt := <-c.events:
-		assert.Fail(t, fmt.Sprintf("Should not have seen an event, but got %v", evt.Type()))
-	case <-time.After(timeout):
-		break
+	case pkt := <-pktChan:
+		assert.True(t, strings.Index(string(pkt), "rackspace.remote.ping.average:4.500000|g|#tenant:123456,entity:,check:chTEST") == 0)
 	}
 }

--- a/poller/connection_stream_test.go
+++ b/poller/connection_stream_test.go
@@ -503,10 +503,10 @@ func TestEleConnectionStream_UseStatsdDistributor(t *testing.T) {
 				buf := make([]byte, 500)
 				_, _, err := udpConn.ReadFrom(buf)
 				if err != nil {
-					t.Fatal(err)
-					return
+					t.Log(err)
+				} else {
+					pktChan <- buf
 				}
-				pktChan <- buf
 			}
 		}
 	}()

--- a/poller/connection_stream_test.go
+++ b/poller/connection_stream_test.go
@@ -543,6 +543,6 @@ func TestEleConnectionStream_UseStatsdDistributor(t *testing.T) {
 		t.Fail()
 
 	case pkt := <-pktChan:
-		assert.Equal(t, "rackspace.remote.ping.average:4.500000|g|#tenant:123456,entity:,check:chTEST,targetIP:", pkt)
+		assert.Regexp(t, "rackspace.remote.ping.average:4.500000|g|#tenant:123456,entity:,check:chTEST,targetIP:,host:.+", pkt)
 	}
 }

--- a/poller/distributor.go
+++ b/poller/distributor.go
@@ -1,0 +1,173 @@
+//
+// Copyright 2017 Rackspace
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package poller
+
+import (
+	"github.com/racker/rackspace-monitoring-poller/config"
+	"context"
+	"github.com/DataDog/datadog-go/statsd"
+	log "github.com/sirupsen/logrus"
+	"github.com/racker/rackspace-monitoring-poller/check"
+	"fmt"
+	"strings"
+)
+
+type MetricsDistributor struct {
+	types []metricsDistributorType
+	ctx   context.Context
+}
+
+type metricsDistributorType interface {
+	Start(ctx context.Context) error
+	Distribute(crs *check.ResultSet)
+}
+
+func NewMetricsDistributor(ctx context.Context, config *config.Config) *MetricsDistributor {
+	distributor := &MetricsDistributor{ctx: ctx}
+
+	var tenantId string
+	tokenParts := strings.Split(config.Token, ".")
+	if len(tokenParts) >= 2 {
+		tenantId = tokenParts[1]
+	}
+
+	if config.StatsdEndpoint != "" {
+		statsdDistributor := newStatsdDistributor(config.StatsdEndpoint, tenantId)
+		if statsdDistributor != nil {
+			distributor.types = append(distributor.types, statsdDistributor)
+		}
+	}
+
+	return distributor
+}
+
+func (md *MetricsDistributor) Start() {
+	for _, d := range md.types {
+		err := d.Start(md.ctx)
+		if err != nil {
+			log.WithError(err).WithField("type", d).Warn("Failed to start distributor type")
+		}
+	}
+}
+
+func (md *MetricsDistributor) Distribute(crs *check.ResultSet) {
+	for _, d := range md.types {
+		d.Distribute(crs)
+	}
+}
+
+type statsdDistributor struct {
+	statsdEndpoint string
+	crsChan        chan *check.ResultSet
+	statsdClient   *statsd.Client
+	tenantId       string
+	ctx            context.Context
+}
+
+func newStatsdDistributor(statsdEndpoint string, tenantId string) metricsDistributorType {
+	d := &statsdDistributor{
+		tenantId:       tenantId,
+		statsdEndpoint: statsdEndpoint,
+	}
+
+	return d
+}
+
+func (d *statsdDistributor) String() string {
+	return fmt.Sprintf("statsdDistributor[endpoint=%s]", d.statsdEndpoint)
+}
+
+func (d *statsdDistributor) Start(ctx context.Context) error {
+	var err error
+	d.statsdClient, err = statsd.New(d.statsdEndpoint)
+	if err != nil {
+		return err
+	}
+	d.statsdClient.Namespace = "rackspace."
+	d.crsChan = make(chan *check.ResultSet, 100)
+
+	log.WithField("endpoint", d.statsdEndpoint).Info("Using statsd metrics distribution type")
+
+	go d.run(ctx)
+
+	return nil
+}
+
+func (d *statsdDistributor) Distribute(crs *check.ResultSet) {
+	d.crsChan <- crs
+}
+
+func (d *statsdDistributor) run(ctx context.Context) {
+	for {
+		select {
+		case crs := <-d.crsChan:
+			d.sendToStatsd(crs)
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (d *statsdDistributor) sendToStatsd(crs *check.ResultSet) {
+
+	ch := crs.Check
+	checkType := ch.GetCheckType()
+	checkID := ch.GetID()
+	entityId := ch.GetEntityID()
+	state := crs.State
+	tags := []string{
+		"tenant:" + d.tenantId,
+		"entity:" + entityId,
+		"check:" + checkID,
+	}
+
+	if targetIp, err := ch.GetTargetIP(); err != nil {
+		tags = append(tags, "targetIP:"+targetIp)
+	}
+
+	for _, result := range crs.Metrics {
+		for name, m := range result.Metrics {
+			metricName := fmt.Sprintf("%s.%s", checkType, name)
+			value, err := m.ToFloat64()
+			if err == nil {
+				log.WithField("metric", metricName).Debug("Sending metric to statsd")
+				d.statsdClient.Gauge(metricName, value, tags, 1)
+			} else {
+				log.WithField("metric", metricName).Debug("Failed to derive float64 value")
+			}
+		}
+	}
+
+	serviceName := checkType
+	serviceCheck := statsd.NewServiceCheck(serviceName, mapStateToServiceCheckStatus(state))
+	serviceCheck.Message = crs.Status
+	serviceCheck.Tags = tags
+	log.WithField("service", serviceName).Debug("Sending service check to statsd")
+	d.statsdClient.ServiceCheck(serviceCheck)
+}
+
+func mapStateToServiceCheckStatus(state string) statsd.ServiceCheckStatus {
+	switch state {
+	case check.StateAvailable:
+		return statsd.Ok
+	case check.StateUnavailable:
+		return statsd.Critical
+	}
+
+	return statsd.Unknown
+}

--- a/poller/distributor.go
+++ b/poller/distributor.go
@@ -24,6 +24,7 @@ import (
 	"github.com/racker/rackspace-monitoring-poller/check"
 	"fmt"
 	"strings"
+	"os"
 )
 
 type MetricsDistributor struct {
@@ -138,6 +139,13 @@ func (d *statsdDistributor) sendToStatsd(crs *check.ResultSet) {
 
 	if targetIp, err := ch.GetTargetIP(); err != nil {
 		tags = append(tags, "targetIP:"+targetIp)
+	}
+
+	hostname, hostnameErr := os.Hostname()
+	if hostnameErr != nil {
+		log.WithError(hostnameErr).Warn("Unable to identify our own hostname")
+	} else {
+		tags = append(tags, "host:"+hostname)
 	}
 
 	for _, result := range crs.Metrics {

--- a/poller/entry.go
+++ b/poller/entry.go
@@ -18,7 +18,7 @@ package poller
 
 import (
 	"context"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/racker/rackspace-monitoring-poller/config"
 	"github.com/racker/rackspace-monitoring-poller/utils"
 	"github.com/satori/go.uuid"

--- a/poller/metrics.go
+++ b/poller/metrics.go
@@ -18,7 +18,7 @@ package poller
 
 import (
 	"context"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/push"
 	"github.com/racker/rackspace-monitoring-poller/config"

--- a/poller/mock_conn_factory_test.go
+++ b/poller/mock_conn_factory_test.go
@@ -1,0 +1,119 @@
+//
+// Copyright 2017 Rackspace
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package poller_test
+
+import (
+	"container/list"
+	"github.com/golang/mock/gomock"
+	"crypto/tls"
+	"testing"
+	"github.com/racker/rackspace-monitoring-poller/poller"
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"time"
+	"github.com/racker/rackspace-monitoring-poller/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/racker/rackspace-monitoring-poller/protocol"
+	"context"
+)
+
+type mockConnFactory struct {
+	conns     *list.List
+	connected chan struct{}
+	frames    chan protocol.Frame
+	guids     []string
+}
+
+func newMockConnFactory() *mockConnFactory {
+	return &mockConnFactory{
+		conns:     list.New(),
+		connected: make(chan struct{}, 10),
+		frames:    make(chan protocol.Frame, 10),
+		guids:     make([]string, 0),
+	}
+}
+
+func (f *mockConnFactory) add(conn *MockConnection) *MockConnection {
+	f.conns.PushBack(conn)
+	auth := make(chan struct{}, 1)
+	conn.EXPECT().Connect(gomock.Any(), gomock.Any(), gomock.Any()).
+		Do(func(ctx context.Context, config *config.Config, tlsConfig *tls.Config) {
+		f.connected <- struct{}{}
+	})
+	conn.EXPECT().Authenticated().AnyTimes().Return(auth)
+	conn.EXPECT().SetAuthenticated().Do(func() {
+		close(auth)
+	})
+	return conn
+}
+
+func (f *mockConnFactory) interceptSend(frame protocol.Frame) {
+	f.frames <- frame
+}
+
+func (f *mockConnFactory) waitForFrame(t *testing.T, timeout time.Duration) protocol.Frame {
+	select {
+	case <-time.After(timeout):
+		assert.Fail(t, "Did not see frame")
+		return nil
+	case f := <-f.frames:
+		return f
+	}
+}
+
+func (f *mockConnFactory) produce(address string, guid string, checksReconciler poller.ChecksReconciler) poller.Connection {
+	if f.conns.Len() > 0 {
+		connection := f.conns.Remove(f.conns.Front()).(poller.Connection)
+		f.guids = append(f.guids, guid)
+		return connection
+	} else {
+		return nil
+	}
+}
+
+func (f *mockConnFactory) waitForConnections(t *testing.T, expect int, timeout time.Duration) {
+	var seen int
+
+	limiter := time.After(timeout)
+
+	for {
+		select {
+		case <-limiter:
+			require.Fail(t, "Did not see enough connections")
+			return
+
+		case <-f.connected:
+			seen++
+			if seen >= expect {
+				return
+			}
+		}
+	}
+}
+
+func (f *mockConnFactory) renderConfig(addresses int) *config.Config {
+	cfg := &config.Config{
+		UseSrv:    false,
+		Addresses: make([]string, addresses),
+	}
+
+	for i := 0; i < addresses; i++ {
+		cfg.Addresses[i] = fmt.Sprintf("c%d", i+1)
+	}
+
+	return cfg
+}

--- a/poller/phasing_event_consumer_test.go
+++ b/poller/phasing_event_consumer_test.go
@@ -1,0 +1,70 @@
+//
+// Copyright 2017 Rackspace
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package poller_test
+
+import (
+	"testing"
+	"github.com/golang/mock/gomock"
+	"fmt"
+	"github.com/racker/rackspace-monitoring-poller/utils"
+	"github.com/stretchr/testify/assert"
+	"time"
+)
+
+// phasingEventConsumer is an event consumer that supports unit testing by providing functions for evaluating the
+// existence or absence of consumed events.
+type phasingEventConsumer struct {
+	events chan utils.Event
+}
+
+func newPhasingEventConsumer() *phasingEventConsumer {
+	return &phasingEventConsumer{
+		events: make(chan utils.Event, 10),
+	}
+}
+
+func (c *phasingEventConsumer) HandleEvent(evt utils.Event) error {
+	c.events <- evt
+	return nil
+}
+
+// waitFor will block the caller until either an event is consumed for the timeout expires.
+// If an event is received, it will use the targetMatcher to evaluate the expectation of the event's Target field.
+// If the timeout expires or the target field is wrong the test context will be failed.
+func (c *phasingEventConsumer) waitFor(t *testing.T, timeout time.Duration, eventType string, targetMatcher gomock.Matcher) {
+	select {
+	case evt := <-c.events:
+		assert.Equal(t, eventType, evt.Type(), "Wrong event type")
+		if !targetMatcher.Matches(evt.Target()) {
+			assert.Fail(t, targetMatcher.String())
+		}
+	case <-time.After(timeout):
+		t.Fail()
+		//assert.Fail(t, "Did not observe an event")
+	}
+}
+
+// assertNoEvent will block the caller until timeout duration unless an event is consumed.
+// If an event is consumed within timeout duration, then the test context will be failed.
+func (c *phasingEventConsumer) assertNoEvent(t *testing.T, timeout time.Duration) {
+	select {
+	case evt := <-c.events:
+		assert.Fail(t, fmt.Sprintf("Should not have seen an event, but got %v", evt.Type()))
+	case <-time.After(timeout):
+		break
+	}
+}

--- a/poller/poller_test.go
+++ b/poller/poller_test.go
@@ -18,7 +18,7 @@ package poller_test
 
 import (
 	"flag"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"testing"
 )

--- a/poller/scheduler.go
+++ b/poller/scheduler.go
@@ -23,7 +23,7 @@ import (
 
 	"errors"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	set "github.com/deckarep/golang-set"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/racker/rackspace-monitoring-poller/check"

--- a/poller/session.go
+++ b/poller/session.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/racker/rackspace-monitoring-poller/check"
 	"github.com/racker/rackspace-monitoring-poller/config"
 	"github.com/racker/rackspace-monitoring-poller/hostinfo"

--- a/protocol/metric/metric.go
+++ b/protocol/metric/metric.go
@@ -20,6 +20,7 @@ package metric
 import (
 	"errors"
 	"fmt"
+	"strconv"
 )
 
 type Metric struct {
@@ -128,12 +129,27 @@ func (m *Metric) ToInt32() (int32, error) {
 }
 
 func (m *Metric) ToFloat64() (float64, error) {
-	if m.Type != MetricFloat {
-		return 0, errors.New("Invalid coercion to float64")
+	if m.Type == MetricString {
+		strVal, ok := m.Value.(string)
+		if !ok {
+			return 0, errors.New("Wrong type for string metric")
+		}
+		return strToFloat(strVal)
 	}
 	value, ok := m.Value.(float64)
 	if !ok {
-		return 0, errors.New("Invalid coercion to float64")
+		// Let's try harder...
+		asStr := fmt.Sprintf("%v", m.Value)
+		return strToFloat(asStr)
 	}
 	return value, nil
+}
+
+func strToFloat(strVal string) (float64, error) {
+	asFloat, err := strconv.ParseFloat(strVal, 32)
+	if err != nil {
+		return 0, errors.New("Invalid coercion to float64")
+	} else {
+		return asFloat, nil
+	}
 }

--- a/protocol/metric/metric_test.go
+++ b/protocol/metric/metric_test.go
@@ -1,0 +1,62 @@
+//
+// Copyright 2017 Rackspace
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package metric_test
+
+import (
+	"testing"
+	"github.com/racker/rackspace-monitoring-poller/protocol/metric"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetric_ToFloat64(t *testing.T) {
+	m := metric.NewMetric("someFloat", "", metric.MetricFloat, 6.0, "")
+	floatVal, err := m.ToFloat64()
+	assert.NoError(t, err)
+	assert.Equal(t, 6.0, floatVal)
+}
+
+func TestMetric_ToFloat64_FromNumber(t *testing.T) {
+	m := metric.NewMetric("someInt", "", metric.MetricNumber, 5, "")
+
+	floatVal, err := m.ToFloat64()
+	assert.NoError(t, err)
+
+	assert.Equal(t, 5.0, floatVal)
+}
+
+func TestMetric_ToFloat64_FromString(t *testing.T) {
+	m := metric.NewMetric("someStringWithFloat", "", metric.MetricString, "7.0", "")
+
+	floatVal, err := m.ToFloat64()
+	assert.NoError(t, err)
+
+	assert.Equal(t, 7.0, floatVal)
+}
+
+func TestMetric_ToFloat64_FromStringNotString(t *testing.T) {
+	m := metric.NewMetric("someStringWithFloat", "", metric.MetricString, 7.0, "")
+
+	_, err := m.ToFloat64()
+	assert.EqualError(t, err, "Wrong type for string metric")
+}
+
+func TestMetric_ToFloat64_FromStringNotNumber(t *testing.T) {
+	m := metric.NewMetric("someStringWithStatus", "", metric.MetricString, "OK", "")
+
+	_, err := m.ToFloat64()
+	assert.EqualError(t, err, "Invalid coercion to float64")
+}

--- a/utils/process.go
+++ b/utils/process.go
@@ -17,7 +17,7 @@
 package utils
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"os/signal"
 	"syscall"

--- a/utils/rlimit.go
+++ b/utils/rlimit.go
@@ -15,7 +15,7 @@
 package utils
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"syscall"
 )
 

--- a/utils/test.go
+++ b/utils/test.go
@@ -21,7 +21,7 @@ import (
 
 	"runtime"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Also
* increase default auth timeout since LON endpoint frequently took longer than 10s
* adapt imports to org name change github.com/sirupsen/logrus
* refactor some of the unit test helpers in connection stream

## tl;dr;

Important changes are in
* poller/connection_stream.go
* poller/distributor.go
