### PR TITLE
systemd service needs to also log to /var/log

### DIFF
--- a/contrib/vms/.gitignore
+++ b/contrib/vms/.gitignore
@@ -1,0 +1,2 @@
+/.vagrant
+/*.log

--- a/pkg/generic/logrotate.cfg
+++ b/pkg/generic/logrotate.cfg
@@ -1,4 +1,5 @@
 /var/log/rackspace-monitoring-poller.log {
+    su
     missingok
     rotate 12
     size 10M
@@ -7,6 +8,6 @@
     notifempty
     create 640 root adm
     postrotate
-      kill -HUP `cat /var/run/rackspace-monitoring-poller.pid`
+      kill -HUP `pidof rackspace-monitoring-poller`
     endscript
 }

--- a/pkg/generic/service.systemd
+++ b/pkg/generic/service.systemd
@@ -3,7 +3,8 @@ After=network.target
 Wants=network-online.target
 
 [Service]
-ExecStart=/usr/bin/rackspace-monitoring-poller serve
+EnvironmentFile=/etc/default/rackspace-monitoring-poller
+ExecStart=/usr/bin/rackspace-monitoring-poller serve --config $CONFIG_FILE $POLLER_SERVE_OPTS
 Restart=always
 RestartSec=5
 LimitNOFILE=16384


### PR DESCRIPTION
also
* change logrotate to use pidof to generically find process to HUP

Internal users were tweaking the service definition to write to the /var/log anyway, but the logrotate wasn't working then because there's no pid file with systemd.

FYI, [here's the pidof command's man page](http://manpages.ubuntu.com/manpages/zesty/man8/pidof.8.html).