### PR TITLE
Pad out the ICMP payload to 64 bytes since that seems to be standard

### DIFF
--- a/check/pinger.go
+++ b/check/pinger.go
@@ -52,6 +52,8 @@ const (
 
 	GooglePingLimit = 64
 
+	// Ping by default pads the ICMP payload out to 64 bytes, but need to subtract 8 bytes for the ICMP header.
+	// The "-s" option of ping in most man pages seems to unofficially document this.
 	PadUpTo = 64 - 8
 )
 


### PR DESCRIPTION
This is a hopeful-fix to match the characteristics of `ping` where by default it pads out the ICMP payload to 64 bytes (when combined with the 8 bytes of ICMP header).