### PR TITLE
check_ping_test needs to put back the PingerFactory since it is global

### DIFF
--- a/check/check_ping.go
+++ b/check/check_ping.go
@@ -128,6 +128,7 @@ packetLoop:
 				if !resp.Timeout {
 					break packetLoop
 				}
+				continue packetLoop
 			}
 
 			if resp.Seq <= 0 || resp.Seq > len(responses) {

--- a/check/check_ping_test.go
+++ b/check/check_ping_test.go
@@ -44,12 +44,17 @@ const checkDataTemplate = `{
 	  "disabled":false
 	  }`
 
-func setup(ctrl *gomock.Controller) *MockPinger {
+func setup(ctrl *gomock.Controller) (*MockPinger, check.PingerFactorySpec) {
 	mockPinger := NewMockPinger(ctrl)
+	originalFactory := check.PingerFactory
 	check.PingerFactory = func(identifier string, remoteAddr string, ipVersion string) (check.Pinger, error) {
 		return mockPinger, nil
 	}
-	return mockPinger
+	return mockPinger, originalFactory
+}
+
+func teardown(originalFactory check.PingerFactorySpec) {
+	check.PingerFactory = originalFactory
 }
 
 func TestPingCheck_ConfirmType(t *testing.T) {
@@ -66,7 +71,8 @@ func TestPingCheck_ConfirmType(t *testing.T) {
 func TestPingCheck_Success(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	mock := setup(ctrl)
+	mock, originalFactory := setup(ctrl)
+	defer teardown(originalFactory)
 
 	const count = 5
 	const timeout = 15
@@ -102,7 +108,8 @@ func TestPingCheck_Success(t *testing.T) {
 func TestPingCheck_OutOfOrderResponse(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	mock := setup(ctrl)
+	mock, originalFactory := setup(ctrl)
+	defer teardown(originalFactory)
 
 	const count = 5
 	const timeout = 15
@@ -139,7 +146,8 @@ func TestPingCheck_OutOfOrderResponse(t *testing.T) {
 func TestPingCheck_PartialResponses(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	mock := setup(ctrl)
+	mock, originalFactory := setup(ctrl)
+	defer teardown(originalFactory)
 
 	const count = 5
 	const timeout = 15

--- a/check/pinger_test.go
+++ b/check/pinger_test.go
@@ -84,14 +84,14 @@ func TestPinger_Concurrent(t *testing.T) {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
 
-	const concurrency = 50
+	const concurrency = 30
 	const pings = 5
 	var wg sync.WaitGroup
 
 	for i := 0; i < concurrency; i++ {
 		wg.Add(1)
 		go func(checkId string) {
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(time.Duration(i) * time.Millisecond)
 			defer wg.Done()
 
 			t.Logf("Starting %s", checkId)


### PR DESCRIPTION
I only encountered this issue when running `go test ./check/...` from the command-line. The ordering was apparently different running in IntelliJ and over in TravisCI.