### PR TITLE
Add cert_end_in metric to ssl checks

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -355,7 +355,9 @@ func (ch *Base) AddTLSMetrics(cr *Result, state tls.ConnectionState) *TLSMetrics
 	cr.AddMetric(metric.NewMetric("cert_subject_alternate_names", "", metric.MetricString, strings.Join(cert.DNSNames, ", "), ""))
 	// START TIME
 	cr.AddMetric(metric.NewMetric("cert_start", "", metric.MetricNumber, cert.NotBefore.Unix(), ""))
-	cr.AddMetric(metric.NewMetric("cert_end", "", metric.MetricNumber, cert.NotAfter.Unix(), ""))
+	certExpiry := cert.NotAfter.Unix()
+	cr.AddMetric(metric.NewMetric("cert_end", "", metric.MetricNumber, certExpiry, ""))
+	cr.AddMetric(metric.NewMetric("cert_end_in", "", metric.MetricNumber, certExpiry - time.Now().Unix(), ""))
 	return tlsMetrics
 }
 

--- a/check/check_http_test.go
+++ b/check/check_http_test.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/racker/rackspace-monitoring-poller/check"
 	"github.com/stretchr/testify/require"
@@ -482,6 +483,12 @@ func TestHTTP_TLS(t *testing.T) {
 	cert_end, _ := cr.GetMetric("cert_end").ToInt64()
 	if cert_end != 3600000000 {
 		t.Fatal("invalid end time")
+	}
+	cert_end_in, _ := cr.GetMetric("cert_end_in").ToInt64()
+	expectedTime := cert_end - time.Now().Unix()
+	// Since thie metric compares against current time, allow a 2s buffer
+	if !IsInRange(cert_end_in, expectedTime, 2) {
+		t.Fatal("invalid end in time")
 	}
 	cert_dns_names, _ := cr.GetMetric("cert_subject_alternate_names").ToString()
 	if cert_dns_names != "example.com" {


### PR DESCRIPTION
Adds the `cert_end_in` metric which compared the `cert_end` time to the current time.

In tests we allow for a 2s difference compared to what we expect in case test slowness occurs.