### PR TITLE
Pinger needs to also handle write timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 - gem install --no-ri --no-rdoc fpm
 script:
 - sudo sysctl -w net.ipv4.ping_group_range="0 2147483647"
-- go test -timeout 30s -short -v $(glide novendor)
+- go test -timeout 60s -short -v $(glide novendor)
 - CGO_ENABLED=0 gox -osarch "linux/386 linux/amd64 darwin/amd64 windows/386 windows/amd64" -output="build/{{.Dir}}_{{.OS}}_{{.Arch}}"
   -ldflags="-X github.com/racker/rackspace-monitoring-poller/version.Version=$(git
   symbolic-ref -q --short HEAD || git describe --tags --exact-match)"

--- a/check/check_ping.go
+++ b/check/check_ping.go
@@ -123,10 +123,9 @@ packetLoop:
 			}).Debug("Got ping response")
 
 			if resp.Err != nil {
-				// Latch the error for consideration and inclusion in the final check result
-				pingErr = resp.Err
 				if !resp.Timeout {
-					break packetLoop
+					// Latch non-timeout errors for consideration and inclusion in the final check result
+					pingErr = resp.Err
 				}
 				continue packetLoop
 			}

--- a/check/check_ping.go
+++ b/check/check_ping.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	defaultPingCount = 5
+	defaultPingCount = 6
 )
 
 // PingCheck conveys Ping checks

--- a/check/check_ping_test.go
+++ b/check/check_ping_test.go
@@ -178,5 +178,5 @@ func TestPingCheck_PartialResponses(t *testing.T) {
 
 	assert.Equal(t, 1, crs.Length())
 	AssertMetrics(t, expected, crs.Get(0).Metrics)
-	assert.False(t, crs.Available)
+	assert.True(t, crs.Available)
 }

--- a/check/pinger_test.go
+++ b/check/pinger_test.go
@@ -85,7 +85,7 @@ func TestPinger_Concurrent(t *testing.T) {
 	}
 
 	const concurrency = 75
-	const pings = 5
+	const pings = 6
 	var wg sync.WaitGroup
 
 	for i := 0; i < concurrency; i++ {

--- a/check/pinger_test.go
+++ b/check/pinger_test.go
@@ -84,7 +84,7 @@ func TestPinger_Concurrent(t *testing.T) {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
 
-	const concurrency = 30
+	const concurrency = 75
 	const pings = 5
 	var wg sync.WaitGroup
 
@@ -100,19 +100,26 @@ func TestPinger_Concurrent(t *testing.T) {
 
 			responses := make([]*check.PingResponse, pings)
 
+			timeouts := 0
+
 			for p := 0; p < pings; p++ {
 				resp := pinger.Ping(p+1, 1*time.Second)
-				require.False(t, resp.Timeout, "not expecting timeout for seq=%d, checkId=%s", p+1, checkId)
+				if resp.Timeout {
+					timeouts++
+					require.True(t, timeouts < 3, "not expecting %d timeouts for seq=%d, checkId=%s", timeouts, p+1, checkId)
+					continue
+				}
 				require.True(t, resp.Seq > 0 && resp.Seq <= pings, "invalid seq from resp=%v", resp)
 				responses[resp.Seq-1] = &resp
 				time.Sleep(10 * time.Millisecond)
 			}
 
 			for p := 0; p < pings; p++ {
-				require.NotNil(t, responses[p], "Missing ping seq=%d,checkId=%s", p+1, checkId)
-				assert.True(t, responses[p].Rtt > 0, "Zero RTT seq=%d", p+1)
-				assert.NoError(t, responses[p].Err, "seq=%d", p+1)
-				assert.False(t, responses[p].Timeout, "seq=%d", p+1)
+				if responses[p] != nil {
+					assert.True(t, responses[p].Rtt > 0, "Zero RTT seq=%d", p+1)
+					assert.NoError(t, responses[p].Err, "seq=%d", p+1)
+					assert.False(t, responses[p].Timeout, "seq=%d", p+1)
+				}
 
 			}
 


### PR DESCRIPTION
Also
* ensure read timeouts don't get latched and mislead alert processing
* increase TestPinger_Concurrent concurrency, but also tolerate missed packets
* fix TestPingCheck_PartialResponses's handling of the partial packet loss, which is not for the check to deem "unavailable"

FYI, packet loss pinging localhost can also be seen using `ping`:
```
rm -rf /tmp/pings; mkdir -p /tmp/pings; cd /tmp/pings; for i in $(seq 0 1 50); do
ping -c 5 -i 0.1 localhost > /tmp/pings/out-${i} &
done

# after those are done

grep "packet loss" /tmp/pings/*
```