### PR TITLE
Always run ping as priveleged mode on Windows (CMC-1987)

### DIFF
--- a/check/pinger.go
+++ b/check/pinger.go
@@ -99,7 +99,8 @@ type pingerBase struct {
 // PingerFactory creates and returns a new pinger that is initialized to a standard implementation, but can be
 // swapped out for unit testing, etc.
 var PingerFactory PingerFactorySpec = func(identifier string, remoteAddr string, ipVersion string) (Pinger, error) {
-	privileged := os.Geteuid() == 0
+	// ICMP on Windows only works as an admin user, so force priviledged mode as such
+	privileged := os.Geteuid() == 0 || runtime.GOOS == "windows"
 	if !privileged {
 		switch runtime.GOOS {
 		case "darwin", "linux":


### PR DESCRIPTION
* Windows doesn't allow applications to use ICMP over UDP at all
* The UID==0 approach we use doesn't properly test for Windows running in elevated privileges
so...just always assume and use privileged mode on Windows. It's OK if it's a bad assumption since the user gets a meaningful error in the logs:

```
An attempt was made to access a socket in a way forbidden by its access permissions.
Unable to create ICMP listener
```
