### PR TITLE
Enforce a max age on connections to avoid proxy hanging on those

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,166 +2,220 @@
 
 
 [[projects]]
+  digest = "1:a92aebe98925bf470dc2f0ebc77c693e3a017db8c17184afff1fa69f936c4233"
   name = "github.com/DataDog/datadog-go"
   packages = ["statsd"]
+  pruneopts = "UT"
   revision = "0ddda6bee21174ef6c4873647cb0d6ec9cba996f"
   version = "1.1.0"
 
 [[projects]]
+  digest = "1:e92f5581902c345eb4ceffdcd4a854fb8f73cf436d47d837d1ec98ef1fe0a214"
   name = "github.com/StackExchange/wmi"
   packages = ["."]
-  revision = "ea383cf3ba6ec950874b8486cd72356d007c768f"
+  pruneopts = "UT"
+  revision = "5d049714c4a64225c3c79a7cf7d02f7fb5b96338"
+  version = "1.0.0"
 
 [[projects]]
+  digest = "1:5bb36304653e73c2ced864d49c9f344e7141a7ceef852442edcea212094ebc3c"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
+  pruneopts = "UT"
   revision = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9"
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "UT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:c166378e8ab0f794f293dfb941d250dd70b035b05dec58879f717621d0fe1714"
   name = "github.com/deckarep/golang-set"
   packages = ["."]
+  pruneopts = "UT"
   revision = "1d4478f51bed434f1dadf96dcd9b43aabac66795"
   version = "v1.7"
 
 [[projects]]
+  digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
+  pruneopts = "UT"
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
   version = "v1.4.7"
 
 [[projects]]
+  digest = "1:fa17ce642b627e8feabf54bdc097191ce502636c05e7b09f0c6a81060b673634"
   name = "github.com/go-ole/go-ole"
   packages = [
     ".",
-    "oleutil"
+    "oleutil",
   ]
+  pruneopts = "UT"
   revision = "2ecd927eaf828c4fc088fae349b28eed1480ff56"
   version = "v0.0.1"
 
 [[projects]]
+  digest = "1:56bb13f8bdd8dfa407645ce4a497b22eb3fd872c990e7393bd693339c2587daa"
   name = "github.com/golang/mock"
   packages = ["gomock"]
+  pruneopts = "UT"
   revision = "61503c535dc549c7ffc1ff07902345658a0f20a2"
 
 [[projects]]
+  digest = "1:9b0e71863f18fc5de645a263184c8a6409ae731e847b35b25da4be818f1975fa"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
+  pruneopts = "UT"
   revision = "130e6b02ab059e7b717a096f397c5b60111cae74"
 
 [[projects]]
+  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
+  pruneopts = "UT"
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
 
 [[projects]]
+  digest = "1:b6bbd2f9e0724bd81890c8644259f920c6d61c08453978faff0bebd25f3e7d3e"
   name = "github.com/jpillora/backoff"
   packages = ["."]
+  pruneopts = "UT"
   revision = "8eab2debe79d12b7bd3d10653910df25fa9552ba"
   version = "1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:caf6db28595425c0e0f2301a00257d11712f65c1878e12cffc42f6b9a9cf3f23"
   name = "github.com/kardianos/osext"
   packages = ["."]
+  pruneopts = "UT"
   revision = "ae77be60afb1dcacde03767a8c37337fad28ac14"
 
 [[projects]]
   branch = "master"
+  digest = "1:2c4470d47613daac5ff660ff9b67a6f8dca489845bb867186e3fcda742a3e53f"
   name = "github.com/kardianos/service"
   packages = ["."]
+  pruneopts = "UT"
   revision = "615a14ed75099c9eaac6949e22ac2341bf9d3197"
 
 [[projects]]
   branch = "master"
+  digest = "1:f44d34fda864bed6d6c71514cd40b2ee097e6e67f745d5d014113e1faa5af8b7"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
+  pruneopts = "UT"
   revision = "b729f2633dfe35f4d1d8a32385f6685610ce1cb5"
 
 [[projects]]
+  digest = "1:a36a1febe1240bb79a208390ad17e1080555b0031a9ed42a41eae173cca3fd74"
   name = "github.com/mattn/go-colorable"
   packages = ["."]
+  pruneopts = "UT"
   revision = "ad5389df28cdac544c99bd7b9161a0b5b6ca9d1b"
 
 [[projects]]
+  digest = "1:d4d17353dbd05cb52a2a52b7fe1771883b682806f68db442b436294926bbfafb"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
+  pruneopts = "UT"
   revision = "a5cdd64afdee435007ee3e9f6ed4684af949d568"
 
 [[projects]]
   branch = "master"
+  digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
+  pruneopts = "UT"
   revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
 
 [[projects]]
   branch = "master"
+  digest = "1:2b32af4d2a529083275afc192d1067d8126b578c7a9613b26600e4df9c735155"
   name = "github.com/mgutz/ansi"
   packages = ["."]
+  pruneopts = "UT"
   revision = "9520e82c474b0a04dd04f8a40959027271bab992"
 
 [[projects]]
+  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = "UT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:925dac484c3a7f05fd4f99bf3d51e426c240193c6edccfc960bca817a5caa5ba"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
-    "prometheus/push"
+    "prometheus/push",
   ]
+  pruneopts = "UT"
   revision = "c5b7fccd204277076155f10851dad72b76a49317"
   version = "v0.8.0"
 
 [[projects]]
+  digest = "1:32d10bdfa8f09ecf13598324dba86ab891f11db3c538b6a34d1c3b5b99d7c36b"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
+  pruneopts = "UT"
   revision = "6f3806018612930941127f2a7c6c453ba2c527d2"
 
 [[projects]]
+  digest = "1:79ac6d18d6b7eabed09995d83689c2c1d3c09dfdd892ddf3d2202765bef23582"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
-    "model"
+    "model",
   ]
+  pruneopts = "UT"
   revision = "1bab55dd05dbff384524a6a1c99006d9eb5f139b"
 
 [[projects]]
+  digest = "1:93ed91deb3bb95cf63bbe5ae3f16eb4b7559b438fc3a3c6917cd12cc31e38c08"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
-    "xfs"
+    "xfs",
   ]
+  pruneopts = "UT"
   revision = "a6e9df898b1336106c743392c48ee0b71f5c4efa"
 
 [[projects]]
+  digest = "1:d676ea255779103729615af11d9e0bd6ac88f247fb5f524edb731138e60f37ea"
   name = "github.com/rackerlabs/go-connect-tunnel"
   packages = ["."]
+  pruneopts = "UT"
   revision = "fbbb5e09a34b84a8527bb6a621892d3a26c1104e"
   version = "1.0.0"
 
 [[projects]]
+  digest = "1:34a99dd0852c5c9c16e9b86884e9e0cb3e4a7a01df4dea7913f85ea7fb786bbe"
   name = "github.com/satori/go.uuid"
   packages = ["."]
+  pruneopts = "UT"
   revision = "879c5887cd475cd7864858769793b2ceb0d44feb"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:5331094ce2c687a921af5ec1367fe96e894e5b6866c2c3b8d415e86b65e69bce"
   name = "github.com/shirou/gopsutil"
   packages = [
     "cpu",
@@ -170,56 +224,72 @@
     "internal/common",
     "mem",
     "net",
-    "process"
+    "process",
   ]
-  revision = "5776ff9c7c5d063d574ef53d740f75c68b448e53"
-  version = "v2.18.02"
+  pruneopts = "UT"
+  revision = "ccc1c1016bc5d10e803189ee43417c50cdde7f1b"
+  version = "v2.18.12"
 
 [[projects]]
   branch = "master"
+  digest = "1:99c6a6dab47067c9b898e8c8b13d130c6ab4ffbcc4b7cc6236c2cd0b1e344f5b"
   name = "github.com/shirou/w32"
   packages = ["."]
+  pruneopts = "UT"
   revision = "bb4de0191aa41b5507caa14b0650cdbddcd9280b"
 
 [[projects]]
+  digest = "1:dc2d85c13ac22c22a1f3170a41a8e1b897fa05134aaf533f16df44f66a25b4a1"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
+  pruneopts = "UT"
   revision = "a67f783a3814b8729bd2dac5780b5f78f8dbd64d"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:7ffc0983035bc7e297da3688d9fe19d60a420e9c38bef23f845c53788ed6a05e"
   name = "github.com/spf13/cobra"
   packages = ["."]
+  pruneopts = "UT"
   revision = "7b2c5ac9fc04fc5efafb60700713d4fa609b777b"
   version = "v0.0.1"
 
 [[projects]]
+  digest = "1:1b21a2b4058a779f290c7341cd93267492e0ecea6c8b54f64a4a5fd7ff131034"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = "UT"
   revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:7e8d267900c7fa7f35129a2a37596e38ed0f11ca746d6d9ba727980ee138f9f6"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "require"
+    "require",
   ]
+  pruneopts = "UT"
   revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
   version = "v1.2.1"
 
 [[projects]]
+  digest = "1:39a425f98fb19427061a693fe6bf0683c9bddec4b25b17067e34fdb465e39cb9"
   name = "github.com/x-cray/logrus-prefixed-formatter"
   packages = ["."]
+  pruneopts = "UT"
   revision = "bb2702d423886830dee131692131d35648c382e2"
   version = "v0.5.2"
 
 [[projects]]
+  digest = "1:624a05c7c6ed502bf77364cd3d54631383dafc169982fddd8ee77b53c3d9cccf"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
+  pruneopts = "UT"
   revision = "bd6f299fb381e4c3393d1c4b1f0b94f5e77650c8"
 
 [[projects]]
+  digest = "1:bff9a9004a767d9fa503aa8065cac22243cc8c81e09bb7012555caa8cc96fcd6"
   name = "golang.org/x/net"
   packages = [
     "bpf",
@@ -228,11 +298,14 @@
     "internal/iana",
     "internal/socket",
     "ipv4",
-    "ipv6"
+    "ipv6",
   ]
+  pruneopts = "UT"
   revision = "c73622c77280266305273cb545f54516ced95b93"
 
 [[projects]]
+  branch = "master"
+  digest = "1:521e62cabd16d284c7437142aa3e7b5687493dbfcfb90ddc1a913b76f47ad434"
   name = "golang.org/x/sys"
   packages = [
     "unix",
@@ -240,13 +313,39 @@
     "windows/registry",
     "windows/svc",
     "windows/svc/eventlog",
-    "windows/svc/mgr"
+    "windows/svc/mgr",
   ]
-  revision = "8dbc5d05d6edcc104950cc299a1ce6641235bc86"
+  pruneopts = "UT"
+  revision = "10058d7d4faa7dd5ef860cbd31af00903076e7b8"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6ae52ac349bdba5e90bf1851a6727763d65904cd501c7180787420233db87f10"
+  input-imports = [
+    "github.com/DataDog/datadog-go/statsd",
+    "github.com/deckarep/golang-set",
+    "github.com/fsnotify/fsnotify",
+    "github.com/golang/mock/gomock",
+    "github.com/jpillora/backoff",
+    "github.com/kardianos/service",
+    "github.com/pkg/errors",
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/push",
+    "github.com/rackerlabs/go-connect-tunnel",
+    "github.com/satori/go.uuid",
+    "github.com/shirou/gopsutil/cpu",
+    "github.com/shirou/gopsutil/disk",
+    "github.com/shirou/gopsutil/host",
+    "github.com/shirou/gopsutil/mem",
+    "github.com/shirou/gopsutil/process",
+    "github.com/sirupsen/logrus",
+    "github.com/spf13/cobra",
+    "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/require",
+    "github.com/x-cray/logrus-prefixed-formatter",
+    "golang.org/x/net/icmp",
+    "golang.org/x/net/ipv4",
+    "golang.org/x/net/ipv6",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -59,7 +59,7 @@
 
 [[constraint]]
   name = "github.com/shirou/gopsutil"
-  version = "~2.18.2"
+  version = "~2.18.12"
 
 [[constraint]]
   name = "github.com/sirupsen/logrus"

--- a/config/config.go
+++ b/config/config.go
@@ -29,10 +29,10 @@ import (
 
 	"bytes"
 	"fmt"
-	log "github.com/sirupsen/logrus"
-	"text/template"
-	"net/url"
 	errors2 "github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"net/url"
+	"text/template"
 )
 
 var (
@@ -52,6 +52,8 @@ const (
 	DefaultReconnectMinBackoff    = 25 * time.Second
 	DefaultReconnectMaxBackoff    = 180 * time.Second
 	DefaultReconnectFactorBackoff = 2
+	DefaultMaxConnectionAge       = 2 * 24 * time.Hour
+	DefaultMaxConnectionAgeJitter = 1 * 24 * time.Hour
 )
 
 type Feature struct {
@@ -95,6 +97,9 @@ type Config struct {
 	// is reset upon receipt of each poller.prepare.block.
 	TimeoutPrepareEnd time.Duration
 
+	MaxConnectionAge       time.Duration
+	MaxConnectionAgeJitter time.Duration
+
 	// If configured, then metrics will be pushed to a Prometheus push gateway at the given URI.
 	// The URI may either have a scheme of "srv" or "tcp". A "srv" refers to a DNS SRV name and "tcp" conveys
 	// a host:port address, typically for local/onsite usage. The given service name will be qualified by the
@@ -134,6 +139,8 @@ func NewConfig(guid string, useStaging bool, features []Feature) *Config {
 	cfg.TimeoutWrite = DefaultTimeoutWrite
 	cfg.TimeoutPrepareEnd = DefaultTimeoutPrepareEnd
 	cfg.TimeoutAuth = DefaultTimeoutAuth
+	cfg.MaxConnectionAge = DefaultMaxConnectionAge
+	cfg.MaxConnectionAgeJitter = DefaultMaxConnectionAgeJitter
 	cfg.UseStaging = useStaging
 	if useStaging {
 		cfg.SrvQueries = DefaultStagingSrvEndpoints

--- a/config/config.go
+++ b/config/config.go
@@ -97,8 +97,8 @@ type Config struct {
 	// is reset upon receipt of each poller.prepare.block.
 	TimeoutPrepareEnd time.Duration
 
-	MaxConnectionAge       time.Duration
-	MaxConnectionAgeJitter time.Duration
+	MaxProxyConnectionAge       time.Duration
+	MaxProxyConnectionAgeJitter time.Duration
 
 	// If configured, then metrics will be pushed to a Prometheus push gateway at the given URI.
 	// The URI may either have a scheme of "srv" or "tcp". A "srv" refers to a DNS SRV name and "tcp" conveys
@@ -139,8 +139,8 @@ func NewConfig(guid string, useStaging bool, features []Feature) *Config {
 	cfg.TimeoutWrite = DefaultTimeoutWrite
 	cfg.TimeoutPrepareEnd = DefaultTimeoutPrepareEnd
 	cfg.TimeoutAuth = DefaultTimeoutAuth
-	cfg.MaxConnectionAge = DefaultMaxConnectionAge
-	cfg.MaxConnectionAgeJitter = DefaultMaxConnectionAgeJitter
+	cfg.MaxProxyConnectionAge = DefaultMaxConnectionAge
+	cfg.MaxProxyConnectionAgeJitter = DefaultMaxConnectionAgeJitter
 	cfg.UseStaging = useStaging
 	if useStaging {
 		cfg.SrvQueries = DefaultStagingSrvEndpoints

--- a/poller/connection_stream.go
+++ b/poller/connection_stream.go
@@ -344,10 +344,12 @@ reconnect:
 		// Successful connection. reset backoff
 		b.Reset()
 
-		if cs.config.MaxConnectionAge > 0 {
+		if cs.config.ProxyUrl != nil && cs.config.MaxConnectionAge > 0 {
 			maxConnectionAge := cs.config.MaxConnectionAge +
 				time.Duration(float64(cs.config.MaxConnectionAgeJitter)*rand.Float64())
 			maxConnectionAgeChan = time.After(maxConnectionAge)
+
+			log.WithField("maxConnectionAge", maxConnectionAge).Debug("Limiting max connection age for proxied connection")
 		}
 
 		for {

--- a/poller/connection_stream.go
+++ b/poller/connection_stream.go
@@ -344,9 +344,9 @@ reconnect:
 		// Successful connection. reset backoff
 		b.Reset()
 
-		if cs.config.ProxyUrl != nil && cs.config.MaxConnectionAge > 0 {
-			maxConnectionAge := cs.config.MaxConnectionAge +
-				time.Duration(float64(cs.config.MaxConnectionAgeJitter)*rand.Float64())
+		if cs.config.ProxyUrl != nil && cs.config.MaxProxyConnectionAge > 0 {
+			maxConnectionAge := cs.config.MaxProxyConnectionAge +
+				time.Duration(float64(cs.config.MaxProxyConnectionAgeJitter)*rand.Float64())
 			maxConnectionAgeChan = time.After(maxConnectionAge)
 
 			log.WithField("maxConnectionAge", maxConnectionAge).Debug("Limiting max connection age for proxied connection")

--- a/poller/connection_stream_test.go
+++ b/poller/connection_stream_test.go
@@ -1,6 +1,7 @@
 package poller_test
 
 import (
+	"net/url"
 	"testing"
 
 	"context"
@@ -142,7 +143,12 @@ func TestEleConnectionStream_ReConnectOldOnes(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	proxyUrl, err := url.Parse("http://localhost:5555")
+	require.NoError(t, err)
+
 	cs := poller.NewCustomConnectionStream(ctx, &config.Config{
+		ProxyUrl:               proxyUrl,
 		MaxConnectionAge:       100 * time.Millisecond,
 		MaxConnectionAgeJitter: 10 * time.Millisecond,
 		ReconnectMinBackoff:    1 * time.Millisecond,

--- a/poller/connection_stream_test.go
+++ b/poller/connection_stream_test.go
@@ -148,14 +148,14 @@ func TestEleConnectionStream_ReConnectOldOnes(t *testing.T) {
 	require.NoError(t, err)
 
 	cs := poller.NewCustomConnectionStream(ctx, &config.Config{
-		ProxyUrl:               proxyUrl,
-		MaxConnectionAge:       100 * time.Millisecond,
-		MaxConnectionAgeJitter: 10 * time.Millisecond,
-		ReconnectMinBackoff:    1 * time.Millisecond,
-		ReconnectMaxBackoff:    1 * time.Millisecond,
-		UseSrv:                 false,
-		Addresses:              []string{"localhost"},
-		SrvQueries:             nil,
+		ProxyUrl:                    proxyUrl,
+		MaxProxyConnectionAge:       100 * time.Millisecond,
+		MaxProxyConnectionAgeJitter: 10 * time.Millisecond,
+		ReconnectMinBackoff:         1 * time.Millisecond,
+		ReconnectMaxBackoff:         1 * time.Millisecond,
+		UseSrv:                      false,
+		Addresses:                   []string{"localhost"},
+		SrvQueries:                  nil,
 	}, nil, connFactory)
 
 	consumer := newPhasingEventConsumer()

--- a/poller/connection_stream_test.go
+++ b/poller/connection_stream_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/racker/rackspace-monitoring-poller/check"
 	"github.com/racker/rackspace-monitoring-poller/config"
 	"github.com/racker/rackspace-monitoring-poller/poller"
-	"github.com/stretchr/testify/assert"
-	"time"
-	"os"
-	"net"
-	"github.com/stretchr/testify/require"
-	"strconv"
 	"github.com/racker/rackspace-monitoring-poller/protocol/metric"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"net"
+	"os"
+	"strconv"
+	"time"
 )
 
 func TestConnectionStream_Connect(t *testing.T) {
@@ -105,6 +105,76 @@ func TestConnectionStream_Connect(t *testing.T) {
 				assert.Fail(t, "Didn't see connection stream closure")
 			}
 		})
+	}
+}
+
+func TestEleConnectionStream_ReConnectOldOnes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	connClosed := make(chan struct{}, 1)
+	reconnect := make(chan struct{}, 1)
+	closureTimeChan := make(chan time.Time, 1)
+
+	conn := NewMockConnection(ctrl)
+	conn.EXPECT().Connect(gomock.Any(), gomock.Any(), gomock.Not(nil))
+	conn.EXPECT().Done().AnyTimes().Return(connClosed)
+	conn.EXPECT().GetLogPrefix().AnyTimes().Return("1234")
+	conn.EXPECT().Close().AnyTimes().Do(func() {
+		t.Log("Mock conn is closing")
+		close(connClosed)
+		closureTimeChan <- time.Now()
+	})
+	preAuthedChannel := make(chan struct{}, 1)
+	close(preAuthedChannel)
+	conn.EXPECT().Authenticated().AnyTimes().Return(preAuthedChannel)
+
+	connFactory := func(address string, guid string, stream poller.ChecksReconciler) poller.Connection {
+		// only provide mock connection until first closure
+		select {
+		case <-connClosed:
+			reconnect <- struct{}{}
+			return nil
+		default:
+			return conn
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cs := poller.NewCustomConnectionStream(ctx, &config.Config{
+		MaxConnectionAge:       100 * time.Millisecond,
+		MaxConnectionAgeJitter: 10 * time.Millisecond,
+		ReconnectMinBackoff:    1 * time.Millisecond,
+		ReconnectMaxBackoff:    1 * time.Millisecond,
+		UseSrv:                 false,
+		Addresses:              []string{"localhost"},
+		SrvQueries:             nil,
+	}, nil, connFactory)
+
+	consumer := newPhasingEventConsumer()
+	cs.RegisterEventConsumer(consumer)
+
+	connectTime := time.Now()
+	cs.Connect()
+	consumer.waitFor(t, 15*time.Millisecond, poller.EventTypeRegister, gomock.Eq(conn))
+
+	select {
+	case closureTime := <-closureTimeChan:
+		closureDelta := closureTime.Sub(connectTime)
+		// expected closure upper bound is at least max age + max age jitter + 10ms more for timing fuzziness
+		assert.True(t, closureDelta >= 100*time.Millisecond && closureDelta < 120*time.Millisecond,
+			"Closure delta is out of bounds", closureDelta)
+		break
+	case <-time.After(150 * time.Millisecond):
+		assert.Fail(t, "Didn't see connection stream closure")
+	}
+
+	select {
+	case <-reconnect:
+		break
+	case <-time.After(10 * time.Millisecond):
+		assert.Fail(t, "Didn't see re-connect")
 	}
 }
 


### PR DESCRIPTION
Fixes https://jira.rax.io/browse/CMC-2237

This is the equivalent fix as this PR
https://github.com/virgo-agent-toolkit/virgo-base-agent/pull/193

We have observed that the long-lived AEP connections via a proxy will sometimes get into a hung state where the poller can't tell the TCP connection is closed yet communication is no longer functional over the connection.

As mentioned in the PR above, the root cause was never determined but a "solution" is to enforce a max age on the connections (2 days plus up to 1 day of jitter) and force the connections to get re-established via the proxy.

Like the agent approach, the jitter is calculated per connection to the AEP, so it is very unlikely that more than one out of the typical three AEP connections would ever be re-connecting at a time.