### PR TITLE
Use amd64 instead of x86_64 for input deb file for reprepro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ PKG_BASE := ${APP_NAME}_${PKG_VERSION}_${PKG_ARCH}
 
 define YAML_HDR
 name: ${APP_NAME}
-arch: ${ARCH}
+arch: ${PKG_ARCH}
 maintainer: ele-dev@lists.rackspace.com
 platform: ${OS}
 version: ${PKG_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,16 @@ OS ?= linux
 # ARCH can be overridden by env variable
 ARCH ?= x86_64
 ifeq (${ARCH}, x86_64)
-# Go uses a GOARCH value of amd64 instead of the standard kernel/packaging convention
+# Go and dpkg uses a GOARCH value of amd64 instead of the kernel arch naming convention
 BIN_ARCH := amd64
+PKG_ARCH := amd64
 else ifeq (${ARCH}, x86)
 # ...and similarly for 386
 BIN_ARCH := 386
+PKG_ARCH := i386
 else
 BIN_ARCH := ${ARCH}
+PKG_ARCH := ${ARCH}
 endif
 
 BIN_NAME := ${EXE}_${OS}_${BIN_ARCH}
@@ -58,7 +61,7 @@ DEB_CONFIG_FILES := ${APP_CFG} ${LOGROTATE_CFG}
 RPM_CONFIG_FILES := ${APP_CFG} ${LOGROTATE_CFG}
 
 PKG_VERSION := ${GIT_TAG}-${TAG_DISTANCE}
-PKG_BASE := ${APP_NAME}_${PKG_VERSION}_${ARCH}
+PKG_BASE := ${APP_NAME}_${PKG_VERSION}_${PKG_ARCH}
 
 
 define YAML_HDR


### PR DESCRIPTION
When performing a release of the PR https://github.com/racker/rackspace-monitoring-poller/pull/189 the build's invocation of reprepro reported the error:

```
using deb packager...
created package: build/rackspace-monitoring-poller_0.2.41-0_x86_64_upstart.deb
mkdir -p build/repos/ubuntu-14.04-x86_64/conf
sed -n -e "p" pkg/debian/repo/conf/distributions > build/repos/ubuntu-14.04-x86_64/conf/distributions
reprepro -b build/repos/ubuntu-14.04-x86_64 includedeb cloudmonitoring build/rackspace-monitoring-poller_0.2.41-0_x86_64_upstart.deb
Error looking at 'build/rackspace-monitoring-poller_0.2.41-0_x86_64_upstart.deb': 'x86_64' is not one of the valid architectures: 'amd64 source'
```

Apparently the resulting architecture part of the name has always been `amd64` looking at the prioro release in the apt repo:
http://stable.poller.packages.cloudmonitoring.rackspace.com/debian/pool/main/r/rackspace-monitoring-poller/